### PR TITLE
[fix] foods sorting order

### DIFF
--- a/src/features/meal-form/utils.ts
+++ b/src/features/meal-form/utils.ts
@@ -41,7 +41,7 @@ export const createInitialFormValues = (
     ]
 
     const sortedFoods = [...mealCategoryFoods].sort((a, b) =>
-      b.createdAt.localeCompare(a.createdAt)
+      a.createdAt.localeCompare(b.createdAt)
     )
 
     return { ...formValues, [mealCategoryName]: sortedFoods }


### PR DESCRIPTION
fix(meal-form): fix food sorting in createInitialFormValues function

Fixes the sorting order of foods in the createInitialFormValues function by correcting the comparison logic to correctly sort based on createdAt timestamps. Previously, the foods were being sorted in the reverse order due to a bug in the comparison function. This commit ensures that foods are correctly sorted in ascending order as intended.