### PR TITLE
[chore] update lodash imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "dayjs": "^1.11.8",
         "eslint": "8.42.0",
         "eslint-config-next": "13.4.4",
-        "lodash-es": "^4.17.21",
+        "lodash.differencewith": "^4.5.0",
+        "lodash.isequal": "^4.5.0",
         "next": "^13.5.6",
         "radash": "^11.0.0",
         "react": "18.2.0",
@@ -38,7 +39,8 @@
         "zustand": "^4.4.1"
       },
       "devDependencies": {
-        "@types/lodash-es": "^4.17.12",
+        "@types/lodash.differencewith": "^4.5.9",
+        "@types/lodash.isequal": "^4.5.8",
         "autoprefixer": "^10.4.14",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-simple-import-sort": "^10.0.0",
@@ -10374,10 +10376,19 @@
       "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
       "dev": true
     },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+    "node_modules/@types/lodash.differencewith": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.differencewith/-/lodash.differencewith-4.5.9.tgz",
+      "integrity": "sha512-nMaREKoe7J3WvnsO7HDRxvnPT3mWmZD3EAECpy7gBGJ6S5nQ66uVlkRe+ZXs6261ZNb2fH9Ny4oUUiSOCmTnLw==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/lodash.isequal": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz",
+      "integrity": "sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==",
       "dev": true,
       "dependencies": {
         "@types/lodash": "*"
@@ -15026,15 +15037,15 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+    },
+    "node_modules/lodash.differencewith": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz",
+      "integrity": "sha512-/8JFjydAS+4bQuo3CpLMBv7WxGFyk7/etOAsrQUCu0a9QVDemxv0YQ0rFyeZvqlUD314SERfNlgnlqqHmaQ0Cg=="
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "dayjs": "^1.11.8",
     "eslint": "8.42.0",
     "eslint-config-next": "13.4.4",
-    "lodash-es": "^4.17.21",
+    "lodash.differencewith": "^4.5.0",
+    "lodash.isequal": "^4.5.0",
     "next": "^13.5.6",
     "radash": "^11.0.0",
     "react": "18.2.0",
@@ -39,7 +40,8 @@
     "zustand": "^4.4.1"
   },
   "devDependencies": {
-    "@types/lodash-es": "^4.17.12",
+    "@types/lodash.differencewith": "^4.5.9",
+    "@types/lodash.isequal": "^4.5.8",
     "autoprefixer": "^10.4.14",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-simple-import-sort": "^10.0.0",

--- a/src/features/meal-form/utils.ts
+++ b/src/features/meal-form/utils.ts
@@ -1,6 +1,6 @@
 import { randomId } from '@mantine/hooks'
-import _differenceWith from 'lodash-es/differenceWith'
-import _isEqual from 'lodash-es/isequal'
+import _differenceWith from 'lodash.differencewith'
+import _isEqual from 'lodash.isequal'
 import { diff, sum } from 'radash'
 
 import { createFoods, deleteFoods, fetchMealDate, updateFoods } from './api'


### PR DESCRIPTION
chore(utils): update lodash imports

The commit updates the import paths for lodash in utils.ts. Switched from using 'lodash-es' to individual lodash imports for 'differenceWith' and 'isEqual'.
