### PR TITLE
feat(meal-record): refactor saveMealRecord to save and update state

### DIFF
--- a/src/api/meal-record/add-meal-record.ts
+++ b/src/api/meal-record/add-meal-record.ts
@@ -4,6 +4,7 @@ import { API } from 'aws-amplify'
 import {
   CreateMealRecordMutation,
   CreateMealRecordMutationVariables,
+  MealRecord,
 } from '../../API'
 import { createMealRecord } from '../../graphql/mutations'
 
@@ -11,11 +12,13 @@ export const addMealRecord = async (
   variables: CreateMealRecordMutationVariables
 ) => {
   try {
-    await API.graphql<GraphQLQuery<CreateMealRecordMutation>>({
+    const { data } = await API.graphql<GraphQLQuery<CreateMealRecordMutation>>({
       query: createMealRecord,
       variables,
       authMode: 'AMAZON_COGNITO_USER_POOLS',
     })
+    const newMealRecord = data?.createMealRecord as MealRecord
+    return newMealRecord
   } catch (err) {
     if (process.env.NODE_ENV !== 'production') {
       console.error('Error creating meal record:', err)

--- a/src/api/meal-record/upd-meal-record.ts
+++ b/src/api/meal-record/upd-meal-record.ts
@@ -2,9 +2,7 @@ import { GraphQLQuery } from '@aws-amplify/api'
 import { API } from 'aws-amplify'
 
 import {
-  FoodItemInput,
   MealRecord,
-  UpdateMealRecordInput,
   UpdateMealRecordMutation,
   UpdateMealRecordMutationVariables,
 } from '../../API'
@@ -14,11 +12,13 @@ export const updMealRecord = async (
   variables: UpdateMealRecordMutationVariables
 ) => {
   try {
-    await API.graphql<GraphQLQuery<UpdateMealRecordMutation>>({
+    const { data } = await API.graphql<GraphQLQuery<UpdateMealRecordMutation>>({
       query: updateMealRecord,
       variables: variables,
       authMode: 'AMAZON_COGNITO_USER_POOLS',
     })
+    const updatedMealRecord = data?.updateMealRecord as MealRecord
+    return updatedMealRecord
   } catch (err) {
     if (process.env.NODE_ENV !== 'production') {
       console.error('Error updating meal record:', err)

--- a/src/features/meal-form/components/MealFormAccordionItem.tsx
+++ b/src/features/meal-form/components/MealFormAccordionItem.tsx
@@ -11,7 +11,7 @@ import { useCurrentDateStore } from '../../../stores'
 import { createStringFromDate } from '../../../utils'
 import { useMealRecordsStore } from '../stores'
 import { FormsType } from '../types'
-import { createFoodInitialValues, saveMealRecord } from '../utils'
+import { createFoodInitialValues, saveAndSetMealRecord } from '../utils'
 import { MealFormFields } from './MealFormFields'
 import { MealIcon } from './MealIcon'
 import { NoFoodText } from './NoFoodText'
@@ -26,7 +26,7 @@ export function MealFormAccordionItem({
   forms,
 }: MealFormAccordionItemProps) {
   const [isSaveButtonDisabled, setIsSaveButtonDisabled] = useState(false)
-  const { mealRecords } = useMealRecordsStore()
+  const { mealRecords, setMealRecords } = useMealRecordsStore()
   const { currentDate } = useCurrentDateStore()
   const currentDateString = createStringFromDate(currentDate)
 
@@ -36,11 +36,12 @@ export function MealFormAccordionItem({
   const handleSave = async () => {
     setIsSaveButtonDisabled(true)
     try {
-      await saveMealRecord(
+      await saveAndSetMealRecord(
         forms,
         mealCategoryName,
         currentDateString,
-        mealRecords
+        mealRecords,
+        setMealRecords
       )
       handleSuccess()
     } catch (err) {

--- a/src/features/meal-form/utils.ts
+++ b/src/features/meal-form/utils.ts
@@ -96,20 +96,22 @@ export const createSumNutritionValues = (forms: FormsType) => {
 }
 
 /**
- * Saves a meal record by either updating an existing record or creating a new one.
+ * Saves and sets a meal record based on the provided forms, meal category name, and current date string.
  *
- * @param forms - The form data containing meal information.
+ * @param forms - The forms containing the meal data to be saved.
  * @param mealCategoryName - The name of the meal category (e.g., breakfast, lunch, dinner).
  * @param currentDateString - The current date as a string.
  * @param mealRecords - The current state of meal records.
+ * @param setMealRecords - The function to update the state of meal records.
  *
- * @returns A promise that resolves when the meal record has been saved.
+ * @returns A promise that resolves when the meal record has been saved and the state has been updated.
  */
-export const saveMealRecord = async (
+export const saveAndSetMealRecord = async (
   forms: FormsType,
   mealCategoryName: string,
   currentDateString: string,
-  mealRecords: MealRecordsState['mealRecords']
+  mealRecords: MealRecordsState['mealRecords'],
+  setMealRecords: MealRecordsState['setMealRecords']
 ) => {
   const mealRecord = mealRecords.find(
     (mealRecord) => mealRecord?.category === mealCategoryName
@@ -125,12 +127,16 @@ export const saveMealRecord = async (
       foods: normalizedFoods,
       _version: mealRecord._version,
     }
-
     const variables: UpdateMealRecordMutationVariables = {
       input: updateMealRecordInput,
     }
 
-    updMealRecord(variables)
+    const updatedMealRecord = await updMealRecord(variables)
+    const newMealRecords = mealRecords.map((mealRecord) =>
+      mealRecord?.category === mealCategoryName ? updatedMealRecord : mealRecord
+    )
+
+    setMealRecords(newMealRecords as MealRecordsState['mealRecords'])
   }
 
   if (!mealRecord) {
@@ -147,7 +153,10 @@ export const saveMealRecord = async (
       input: createMealRecordInput,
     }
 
-    addMealRecord(variables)
+    const newMealRecord = await addMealRecord(variables)
+    const newMealRecords = [...mealRecords, newMealRecord]
+
+    setMealRecords(newMealRecords as MealRecordsState['mealRecords'])
   }
 }
 
@@ -195,5 +204,6 @@ export const fetchAndSetMealRecords = async (
   }
 
   const uniqueMealRecordsWithFoods = await fetchMealRecords(variables)
+
   setMealRecords(uniqueMealRecordsWithFoods as MealRecordsState['mealRecords'])
 }


### PR DESCRIPTION
This commit refactors the saveMealRecord function into saveAndSetMealRecord, which now handles both saving a meal record (either by creating a new record or updating an existing one) and updating the local state of meal records. The changes simplify the data flow within the MealFormAccordionItem component by integrating the state management directly into the save operation, ensuring that the meal records state is always in sync with the backend. This improvement enhances the overall responsiveness of the application and reduces potential discrepancies between displayed data and backend storage.