### PR TITLE
feat(meal-form): implement dynamic default meal category based on current time

### DIFF
--- a/src/features/meal-form/components/MealForm.tsx
+++ b/src/features/meal-form/components/MealForm.tsx
@@ -12,6 +12,7 @@ import {
   createInitialFormValues,
   createSumNutritionValues,
   fetchAndSetMealRecords,
+  getDefaultCategory,
 } from '../utils'
 import { MealFormAccordionItem } from './MealFormAccordionItem'
 
@@ -27,6 +28,8 @@ export function MealForm() {
 
   const mealCategoryNames: string[] = Object.values(MealCategoryName)
   const currentDateString = createStringFromDate(currentDate)
+  const defaultCategory = getDefaultCategory()
+
   const forms: FormsType = useForm({})
   const {
     sumDailyCalories,
@@ -67,7 +70,7 @@ export function MealForm() {
         Daily Meals
       </Text>
 
-      <Accordion defaultValue={mealCategoryNames[0]} variant="separated">
+      <Accordion defaultValue={defaultCategory} variant="separated">
         {mealCategoryNames.map((mealCategoryName) => (
           <MealFormAccordionItem
             key={mealCategoryName}

--- a/src/features/meal-form/utils.ts
+++ b/src/features/meal-form/utils.ts
@@ -64,6 +64,34 @@ export const createInitialFormValues = (
 }
 
 /**
+ * Returns the default meal category based on the current hour of the day.
+ *
+ * - If the current hour is before 11 AM, it returns `MealCategoryName.BREAKFAST`.
+ * - If the current hour is between 11 AM and 2 PM, it returns `MealCategoryName.LUNCH`.
+ * - If the current hour is between 2 PM and 5 PM, it returns `MealCategoryName.SNACK`.
+ * - If the current hour is after 5 PM, it returns `MealCategoryName.DINNER`.
+ *
+ * @returns {MealCategoryName} The default meal category for the current time.
+ */
+export const getDefaultCategory = () => {
+  const currentHour = new Date().getHours()
+
+  if (currentHour < 11) {
+    return MealCategoryName.BREAKFAST
+  }
+
+  if (currentHour < 14) {
+    return MealCategoryName.LUNCH
+  }
+
+  if (currentHour < 17) {
+    return MealCategoryName.SNACK
+  }
+
+  return MealCategoryName.DINNER
+}
+
+/**
  * Calculates the sum of nutritional values (calories, protein, fat, and carbohydrates)
  * from a given set of forms.
  *


### PR DESCRIPTION
Added a new utility function, getDefaultCategory, that determines the default meal category (Breakfast, Lunch, Snack, Dinner) based on the current hour. Updated the MealForm component to utilize this function for setting the default value of the Accordion, enhancing the user experience by providing contextually relevant meal options.