### PR TITLE
feat(meal-form): replace randomId with cuid2 for unique IDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mantine/form": "^7.9.1",
         "@mantine/hooks": "^7.9.1",
         "@mantine/notifications": "^7.10.1",
+        "@paralleldrive/cuid2": "^2.2.2",
         "@tabler/icons-react": "^3.5.0",
         "@types/node": "^20.14.0",
         "@types/react": "^18.3.3",
@@ -9097,6 +9098,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -9127,6 +9140,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@mantine/form": "^7.9.1",
     "@mantine/hooks": "^7.9.1",
     "@mantine/notifications": "^7.10.1",
+    "@paralleldrive/cuid2": "^2.2.2",
     "@tabler/icons-react": "^3.5.0",
     "@types/node": "^20.14.0",
     "@types/react": "^18.3.3",

--- a/src/features/meal-form/utils.ts
+++ b/src/features/meal-form/utils.ts
@@ -1,4 +1,4 @@
-import { randomId } from '@mantine/hooks'
+import { createId } from '@paralleldrive/cuid2'
 import _differenceWith from 'lodash.differencewith'
 import _isEqual from 'lodash.isequal'
 import { sort, sum } from 'radash'
@@ -26,7 +26,7 @@ import { FormField, FormsType } from './types'
  */
 export const createFoodInitialValues = (): FormField => {
   return {
-    id: randomId(),
+    id: createId(),
     name: '',
     calories: '',
     protein: '',
@@ -171,7 +171,7 @@ export const saveAndSetMealRecord = async (
     const normalizedFoods = normalizeFoods(forms, mealCategoryName)
 
     const createMealRecordInput: CreateMealRecordInput = {
-      id: randomId(),
+      id: createId(),
       date: currentDateString,
       category: mealCategoryName as MealCategoryName,
       foods: normalizedFoods,


### PR DESCRIPTION
Updated the identification mechanism in the meal form to use the `createId` function from the newly added `@paralleldrive/cuid2` package, replacing the previous `randomId` method. This change enhances the uniqueness and consistency of generated IDs across meal records. Additionally, `@paralleldrive/cuid2` was added as a dependency in both `package.json` and `package-lock.json`, ensuring that it is available for use in the project.