### PR TITLE
feat(layout): add icon styling for LayoutHeader

### DIFF
--- a/src/components/LayoutHeader/LayoutHeader.module.css
+++ b/src/components/LayoutHeader/LayoutHeader.module.css
@@ -1,0 +1,8 @@
+.iconContainer {
+  margin-top: 4px;
+  margin-left: 14px;
+  margin-right: 4px;
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+}

--- a/src/components/LayoutHeader/LayoutHeader.tsx
+++ b/src/components/LayoutHeader/LayoutHeader.tsx
@@ -1,6 +1,8 @@
 import { Box, Burger, Image, Title, useMantineTheme } from '@mantine/core'
 import { Dispatch, SetStateAction } from 'react'
 
+import styles from './LayoutHeader.module.css'
+
 type LayoutHeaderProps = {
   navbarOpened: boolean
   setNavbarOpened: Dispatch<SetStateAction<boolean>>
@@ -22,8 +24,8 @@ export function LayoutHeader({
         color={theme.colors.gray[6]}
       />
 
-      <Box mt={4} ml={10} mr={8}>
-        <Image src="/favicon.ico" alt="App Icon" width={32} height={32} />
+      <Box className={styles.iconContainer}>
+        <Image src="/favicon.ico" alt="App Icon" />
       </Box>
       <Title order={3} w={800} fw={200}>
         Tracking Your Daily Diet


### PR DESCRIPTION
This commit introduces a new CSS module for the LayoutHeader component, defining an icon container with specific margins and dimensions. 
The Box component is updated to utilize this new styling, enhancing the layout's appearance and ensuring consistency across different screen sizes. 
This change paves the way for easier maintenance and potential future enhancements of the header's UI.