### PR TITLE
feat(api): add user meal preset functionality

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,2 +1,3 @@
 export * from './daily-goal'
 export * from './meal-record'
+export * from './user-meal-preset'

--- a/src/api/user-meal-preset/add-user-meal-preset.ts
+++ b/src/api/user-meal-preset/add-user-meal-preset.ts
@@ -29,7 +29,7 @@ export const addUserMealPreset = async (
     const newUserMealPreset = data?.createUserMealPreset as UserMealPreset
 
     if (!newUserMealPreset) {
-      console.warn('Failed to create user meal preset')
+      throw new Error('Failed to create user meal preset')
     }
 
     return newUserMealPreset

--- a/src/api/user-meal-preset/add-user-meal-preset.ts
+++ b/src/api/user-meal-preset/add-user-meal-preset.ts
@@ -1,0 +1,40 @@
+import { GraphQLQuery } from '@aws-amplify/api'
+import { API } from 'aws-amplify'
+
+import {
+  CreateUserMealPresetMutation,
+  CreateUserMealPresetMutationVariables,
+  UserMealPreset,
+} from '../../API'
+import { createUserMealPreset } from '../../graphql/mutations'
+
+/**
+ * Creates a new user meal preset.
+ *
+ * @param variables - The variables for creating a user meal preset.
+ * @returns The newly created user meal preset.
+ */
+export const addUserMealPreset = async (
+  variables: CreateUserMealPresetMutationVariables
+): Promise<UserMealPreset> => {
+  try {
+    const { data } = await API.graphql<
+      GraphQLQuery<CreateUserMealPresetMutation>
+    >({
+      query: createUserMealPreset,
+      variables,
+      authMode: 'AMAZON_COGNITO_USER_POOLS',
+    })
+
+    const newUserMealPreset = data?.createUserMealPreset as UserMealPreset
+
+    if (!newUserMealPreset) {
+      console.warn('Failed to create user meal preset')
+    }
+
+    return newUserMealPreset
+  } catch (error) {
+    console.error('Error creating user meal preset:', error)
+    throw error
+  }
+}

--- a/src/api/user-meal-preset/fetch-user-meal-preset.ts
+++ b/src/api/user-meal-preset/fetch-user-meal-preset.ts
@@ -1,0 +1,41 @@
+import { GraphQLQuery } from '@aws-amplify/api'
+import { API } from 'aws-amplify'
+
+import {
+  ListUserMealPresetsQuery,
+  ListUserMealPresetsQueryVariables,
+  UserMealPreset,
+} from '../../API'
+import { listUserMealPresets } from '../../graphql/queries'
+
+/**
+ * Fetches the user meal preset data.
+ * Since each user should have only one preset, we fetch the first one from the list.
+ *
+ * @param variables - Optional query variables to filter the presets.
+ * @returns The user's meal preset or null if not found.
+ */
+export const fetchUserMealPreset = async (
+  variables?: ListUserMealPresetsQueryVariables
+): Promise<UserMealPreset | null> => {
+  try {
+    const { data } = await API.graphql<GraphQLQuery<ListUserMealPresetsQuery>>({
+      query: listUserMealPresets,
+      variables,
+      authMode: 'AMAZON_COGNITO_USER_POOLS',
+    })
+
+    const userMealPresets = data?.listUserMealPresets?.items || []
+    const userMealPreset = userMealPresets[0] as UserMealPreset
+
+    if (!userMealPreset) {
+      console.warn('No user meal preset found')
+      return null
+    }
+
+    return userMealPreset
+  } catch (error) {
+    console.error('Error fetching user meal preset:', error)
+    throw error
+  }
+}

--- a/src/api/user-meal-preset/index.ts
+++ b/src/api/user-meal-preset/index.ts
@@ -1,0 +1,3 @@
+export { addUserMealPreset } from './add-user-meal-preset'
+export { fetchUserMealPreset } from './fetch-user-meal-preset'
+export { updUserMealPreset } from './upd-user-meal-preset'

--- a/src/api/user-meal-preset/upd-user-meal-preset.ts
+++ b/src/api/user-meal-preset/upd-user-meal-preset.ts
@@ -29,7 +29,7 @@ export const updUserMealPreset = async (
     const updatedUserMealPreset = data?.updateUserMealPreset as UserMealPreset
 
     if (!updatedUserMealPreset) {
-      console.warn('Failed to update user meal preset')
+      throw new Error('Failed to update user meal preset')
     }
 
     return updatedUserMealPreset

--- a/src/api/user-meal-preset/upd-user-meal-preset.ts
+++ b/src/api/user-meal-preset/upd-user-meal-preset.ts
@@ -1,0 +1,40 @@
+import { GraphQLQuery } from '@aws-amplify/api'
+import { API } from 'aws-amplify'
+
+import {
+  UpdateUserMealPresetMutation,
+  UpdateUserMealPresetMutationVariables,
+  UserMealPreset,
+} from '../../API'
+import { updateUserMealPreset } from '../../graphql/mutations'
+
+/**
+ * Updates an existing user meal preset.
+ *
+ * @param variables - The variables for updating a user meal preset.
+ * @returns The updated user meal preset.
+ */
+export const updUserMealPreset = async (
+  variables: UpdateUserMealPresetMutationVariables
+): Promise<UserMealPreset> => {
+  try {
+    const { data } = await API.graphql<
+      GraphQLQuery<UpdateUserMealPresetMutation>
+    >({
+      query: updateUserMealPreset,
+      variables,
+      authMode: 'AMAZON_COGNITO_USER_POOLS',
+    })
+
+    const updatedUserMealPreset = data?.updateUserMealPreset as UserMealPreset
+
+    if (!updatedUserMealPreset) {
+      console.warn('Failed to update user meal preset')
+    }
+
+    return updatedUserMealPreset
+  } catch (error) {
+    console.error('Error updating user meal preset:', error)
+    throw error
+  }
+}


### PR DESCRIPTION
Introduced user meal preset functionality with methods to add, fetch, and update presets. This includes new API endpoints for handling user meal presets using GraphQL operations. Additionally, added export statements to ensure these methods are accessible from the API module.