### PR TITLE
feat: add MealFormButtons, MealFormContent, and PresetMealFormContentcomponents

### DIFF
--- a/src/components/MealFormButtons/MealFormButtons.tsx
+++ b/src/components/MealFormButtons/MealFormButtons.tsx
@@ -1,0 +1,24 @@
+import { Button, Center } from '@mantine/core'
+
+type MealFormButtonsProps = {
+  onAdd: () => void
+  onSave: () => Promise<void>
+  isSaveButtonDisabled: boolean
+}
+
+export function MealFormButtons({
+  onAdd,
+  onSave,
+  isSaveButtonDisabled,
+}: MealFormButtonsProps) {
+  return (
+    <Center mt="xl">
+      <Button mr="md" onClick={onAdd}>
+        追加
+      </Button>
+      <Button color="teal" onClick={onSave} disabled={isSaveButtonDisabled}>
+        保存
+      </Button>
+    </Center>
+  )
+}

--- a/src/components/MealFormButtons/index.ts
+++ b/src/components/MealFormButtons/index.ts
@@ -1,0 +1,1 @@
+export * from './MealFormButtons'

--- a/src/features/daily-meal-form/components/MealFormAccordionItem.tsx
+++ b/src/features/daily-meal-form/components/MealFormAccordionItem.tsx
@@ -1,12 +1,11 @@
-import { Accordion, Button, Center } from '@mantine/core'
+import { Accordion } from '@mantine/core'
 import { Notifications } from '@mantine/notifications'
 import { useState } from 'react'
 
 import { MealCategoryName } from '@/API'
 
-import { LoadingSkeleton } from '../../../components/LoadingSkeleton'
+import { MealFormButtons } from '../../../components/MealFormButtons'
 import { MealIcon } from '../../../components/MealIcon'
-import { NoFoodText } from '../../../components/NoFoodText'
 import { NOTIFICATION_DISPLAY_DURATION_MS } from '../../../constants'
 import { useCurrentDateStore } from '../../../stores'
 import { createStringFromDate, showNotification } from '../../../utils'
@@ -14,7 +13,7 @@ import { MEAL_CATEGORY_LABELS } from '../constants'
 import { useMealRecordsStore } from '../stores'
 import { FormsType } from '../types'
 import { createFoodInitialValues, saveAndSetMealRecord } from '../utils'
-import { MealFormFields } from './MealFormFields'
+import { MealFormContent } from './MealFormContent'
 
 type MealFormAccordionItemProps = {
   mealCategoryName: MealCategoryName
@@ -70,25 +69,16 @@ export function MealFormAccordionItem({
       </Accordion.Control>
 
       <Accordion.Panel>
-        {isLoading ? (
-          <LoadingSkeleton height={100} />
-        ) : forms.values[mealCategoryName]?.length > 0 ? (
-          <MealFormFields form={forms} mealCategoryName={mealCategoryName} />
-        ) : (
-          <NoFoodText />
-        )}
-        <Center mt="xl">
-          <Button mr="md" onClick={handleAdd}>
-            追加
-          </Button>
-          <Button
-            color="teal"
-            onClick={handleSave}
-            disabled={isSaveButtonDisabled}
-          >
-            保存
-          </Button>
-        </Center>
+        <MealFormContent
+          mealCategoryName={mealCategoryName}
+          forms={forms}
+          isLoading={isLoading}
+        />
+        <MealFormButtons
+          onAdd={handleAdd}
+          onSave={handleSave}
+          isSaveButtonDisabled={isSaveButtonDisabled}
+        />
       </Accordion.Panel>
 
       <Notifications limit={10} autoClose={NOTIFICATION_DISPLAY_DURATION_MS} />

--- a/src/features/daily-meal-form/components/MealFormContent.tsx
+++ b/src/features/daily-meal-form/components/MealFormContent.tsx
@@ -1,0 +1,28 @@
+import { MealCategoryName } from '@/API'
+
+import { LoadingSkeleton } from '../../../components/LoadingSkeleton'
+import { NoFoodText } from '../../../components/NoFoodText'
+import { FormsType } from '../types'
+import { MealFormFields } from './MealFormFields'
+
+type MealFormContentProps = {
+  mealCategoryName: MealCategoryName
+  forms: FormsType
+  isLoading: boolean
+}
+
+export function MealFormContent({
+  mealCategoryName,
+  forms,
+  isLoading,
+}: MealFormContentProps) {
+  if (isLoading) {
+    return <LoadingSkeleton height={100} />
+  }
+
+  if (forms.values[mealCategoryName]?.length > 0) {
+    return <MealFormFields form={forms} mealCategoryName={mealCategoryName} />
+  }
+
+  return <NoFoodText />
+}

--- a/src/features/preset-meal-form/components/PresetMealFormAccordionItem.tsx
+++ b/src/features/preset-meal-form/components/PresetMealFormAccordionItem.tsx
@@ -1,19 +1,18 @@
-import { Accordion, Button, Center } from '@mantine/core'
+import { Accordion } from '@mantine/core'
 import { Notifications } from '@mantine/notifications'
 import { useState } from 'react'
 
 import { MealCategoryName } from '@/API'
 
-import { LoadingSkeleton } from '../../../components/LoadingSkeleton'
+import { MealFormButtons } from '../../../components/MealFormButtons'
 import { MealIcon } from '../../../components/MealIcon'
-import { NoFoodText } from '../../../components/NoFoodText'
 import { NOTIFICATION_DISPLAY_DURATION_MS } from '../../../constants'
 import { showNotification } from '../../../utils'
 import { MEAL_CATEGORY_LABELS } from '../constants'
 import { useUserMealPresetStore } from '../stores'
 import { FormsType } from '../types'
 import { createFoodInitialValues, saveUserMealPreset } from '../utils'
-import { PresetMealFormFields } from './PresetMealFormFields'
+import { PresetMealFormContent } from './PresetMealFormContent'
 
 type PresetMealFormAccordionItemProps = {
   mealCategoryName: MealCategoryName
@@ -66,29 +65,16 @@ export function PresetMealFormAccordionItem({
       </Accordion.Control>
 
       <Accordion.Panel>
-        {isLoading ? (
-          <LoadingSkeleton height={100} />
-        ) : forms.values[mealCategoryName]?.length > 0 ? (
-          <PresetMealFormFields
-            form={forms}
-            mealCategoryName={mealCategoryName}
-          />
-        ) : (
-          <NoFoodText />
-        )}
-
-        <Center mt="xl">
-          <Button mr="md" onClick={handleAdd} disabled={isLoading}>
-            追加
-          </Button>
-          <Button
-            color="teal"
-            onClick={handleSave}
-            disabled={isSaveButtonDisabled || isLoading}
-          >
-            保存
-          </Button>
-        </Center>
+        <PresetMealFormContent
+          mealCategoryName={mealCategoryName}
+          forms={forms}
+          isLoading={isLoading}
+        />
+        <MealFormButtons
+          onAdd={handleAdd}
+          onSave={handleSave}
+          isSaveButtonDisabled={isSaveButtonDisabled}
+        />
       </Accordion.Panel>
 
       <Notifications limit={10} autoClose={NOTIFICATION_DISPLAY_DURATION_MS} />

--- a/src/features/preset-meal-form/components/PresetMealFormContent.tsx
+++ b/src/features/preset-meal-form/components/PresetMealFormContent.tsx
@@ -1,0 +1,30 @@
+import { MealCategoryName } from '@/API'
+
+import { LoadingSkeleton } from '../../../components/LoadingSkeleton'
+import { NoFoodText } from '../../../components/NoFoodText'
+import { FormsType } from '../types'
+import { PresetMealFormFields } from './PresetMealFormFields'
+
+type MealFormContentProps = {
+  mealCategoryName: MealCategoryName
+  forms: FormsType
+  isLoading: boolean
+}
+
+export function PresetMealFormContent({
+  mealCategoryName,
+  forms,
+  isLoading,
+}: MealFormContentProps) {
+  if (isLoading) {
+    return <LoadingSkeleton height={100} />
+  }
+
+  if (forms.values[mealCategoryName]?.length > 0) {
+    return (
+      <PresetMealFormFields form={forms} mealCategoryName={mealCategoryName} />
+    )
+  }
+
+  return <NoFoodText />
+}


### PR DESCRIPTION
This pull request refactors the meal form components to improve reusability and maintainability by extracting shared logic into new components. The changes include the creation of `MealFormButtons` and `MealFormContent` components, their integration into existing meal form features, and the removal of duplicate code.

### Component Extraction and Reusability:

* [`src/components/MealFormButtons/MealFormButtons.tsx`](diffhunk://#diff-b56383d3873e9ab1a3de73391bba4802a22cff634bb7017c3ab44fb359307e3fR1-R24): Introduced a new `MealFormButtons` component to encapsulate the "Add" and "Save" button functionality.
* [`src/components/MealFormButtons/index.ts`](diffhunk://#diff-9d4760c65154cd4d7acb373e40ac5883b144075b027a897b17742b61a22a18e4R1): Added an export for the new `MealFormButtons` component.
* [`src/features/daily-meal-form/components/MealFormContent.tsx`](diffhunk://#diff-517f87cb98ea66c35ad45af7895b00e7aee8854d6a04a70ae09da8ec946b7b4cR1-R28): Created a `MealFormContent` component to handle the conditional rendering of loading skeletons, meal form fields, and "No Food" text.
* [`src/features/preset-meal-form/components/PresetMealFormContent.tsx`](diffhunk://#diff-89dc74b27354ede94594ce3fe27727d574ba811c486c465ea53c1b2380f65f6cR1-R30): Added a `PresetMealFormContent` component similar to `MealFormContent`, tailored for preset meal forms.

### Integration into Existing Features:

* [`src/features/daily-meal-form/components/MealFormAccordionItem.tsx`](diffhunk://#diff-89b61e927f4ee912586c09c7cf9e01ed851e805307e47f0b5358397770f78ce1L1-R16): Replaced inline button and content logic with the newly created `MealFormButtons` and `MealFormContent` components. This simplifies the code and reduces duplication. [[1]](diffhunk://#diff-89b61e927f4ee912586c09c7cf9e01ed851e805307e47f0b5358397770f78ce1L1-R16) [[2]](diffhunk://#diff-89b61e927f4ee912586c09c7cf9e01ed851e805307e47f0b5358397770f78ce1L73-R81)
* [`src/features/preset-meal-form/components/PresetMealFormAccordionItem.tsx`](diffhunk://#diff-ed5841bf20775fea2b92ba36add968554aad87704da1a9d6b13d0182e33b7ec0L1-R15): Updated to use `MealFormButtons` and `PresetMealFormContent`, streamlining the implementation and aligning with the refactored structure. [[1]](diffhunk://#diff-ed5841bf20775fea2b92ba36add968554aad87704da1a9d6b13d0182e33b7ec0L1-R15) [[2]](diffhunk://#diff-ed5841bf20775fea2b92ba36add968554aad87704da1a9d6b13d0182e33b7ec0L69-L91)