### PR TITLE
feat: add centerContent prop to Layout component and apply centering

### DIFF
--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -1,0 +1,7 @@
+/* filepath: /Users/main/Dev/project/tracking-your-daily-diet/src/components/Layout/Layout.module.css */
+.center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}

--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -1,4 +1,3 @@
-/* filepath: /Users/main/Dev/project/tracking-your-daily-diet/src/components/Layout/Layout.module.css */
 .center {
   display: flex;
   justify-content: center;

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -4,17 +4,20 @@ import { ReactNode, useState } from 'react'
 
 import { LayoutHeader } from '../LayoutHeader'
 import { LayoutNavBar } from '../LayoutNavBar'
+import classes from './Layout.module.css'
 
 type LayoutProps = {
   title: string
   children: ReactNode
   showNavBar?: boolean
+  centerContent?: boolean
 }
 
 export function Layout({
   title = '',
   children,
   showNavBar = true,
+  centerContent = false,
 }: LayoutProps) {
   const [navbarOpened, setNavbarOpened] = useState(false)
 
@@ -35,7 +38,7 @@ export function Layout({
             : undefined
         }
         header={{ height: 60 }}
-        padding="lg"
+        mt={20}
       >
         <AppShell.Header>
           <LayoutHeader
@@ -50,7 +53,7 @@ export function Layout({
           </AppShell.Navbar>
         )}
 
-        <AppShell.Main>
+        <AppShell.Main className={centerContent ? classes.center : undefined}>
           <Container size="md" m="md">
             {children}
           </Container>

--- a/src/pages/landingpage.tsx
+++ b/src/pages/landingpage.tsx
@@ -3,7 +3,7 @@ import { Layout } from '../components/Layout'
 
 export default function Lp() {
   return (
-    <Layout title="LandingPage" showNavBar={false}>
+    <Layout title="LandingPage" showNavBar={false} centerContent={true}>
       <LandingPage />
     </Layout>
   )


### PR DESCRIPTION
This pull request introduces a new `centerContent` prop to the `Layout` component, allowing for centralized alignment of content. It also updates the `LandingPage` to utilize this new feature. Below are the key changes:

### Enhancements to the `Layout` Component:

* Added a new CSS class `.center` in `Layout.module.css` to enable centralized alignment of content. (`src/components/Layout/Layout.module.css`, [src/components/Layout/Layout.module.cssR1-R6](diffhunk://#diff-4ab3ce63bad972b72a76c7bcf0944426e401fe820eda78f097f968c485d8a185R1-R6))
* Introduced a `centerContent` boolean prop to the `Layout` component, defaulting to `false`, to conditionally apply the `.center` class for central alignment. (`src/components/Layout/Layout.tsx`, [[1]](diffhunk://#diff-8780de126d54dfa810671169d12e1f8fdf8267c3655f9eb20089aeeeb6ad5fcbR7-R20) [[2]](diffhunk://#diff-8780de126d54dfa810671169d12e1f8fdf8267c3655f9eb20089aeeeb6ad5fcbL53-R56)
* Adjusted the `AppShell` padding to use a margin-top (`mt={20}`) instead of `padding="lg"` for better spacing consistency. (`src/components/Layout/Layout.tsx`, [src/components/Layout/Layout.tsxL38-R41](diffhunk://#diff-8780de126d54dfa810671169d12e1f8fdf8267c3655f9eb20089aeeeb6ad5fcbL38-R41))

### Updates to `LandingPage`:

* Updated the `LandingPage` to pass `centerContent={true}` to the `Layout` component, enabling centralized alignment for its content. (`src/pages/landingpage.tsx`, [src/pages/landingpage.tsxL6-R6](diffhunk://#diff-321bafc4695159ba2423ac0e666b9f6350d03032f30d8fe85ae3aa1c1ec59391L6-R6))