### PR TITLE
feat: translate UI labels for localization

### DIFF
--- a/e2e/tests/settings-page.spec.ts
+++ b/e2e/tests/settings-page.spec.ts
@@ -8,7 +8,7 @@ test.describe('Settings Page Tests', () => {
   })
 
   test('should save settings correctly', async ({ page }) => {
-    await page.getByRole('link', { name: 'Settings' }).click()
+    await page.getByRole('link', { name: '目標設定' }).click()
     await expect(page).toHaveURL(/\/settings/)
 
     await page.getByPlaceholder('Calories').fill('2000')
@@ -18,7 +18,7 @@ test.describe('Settings Page Tests', () => {
     await page.getByRole('button', { name: 'Save' }).click()
 
     await page.reload()
-    await page.getByRole('link', { name: 'Settings' }).click()
+    await page.getByRole('link', { name: '目標設定' }).click()
 
     await expect(page).toHaveURL(/\/settings/)
     await expect(page.getByPlaceholder('Calories')).toHaveValue('2000')

--- a/src/components/LayoutNavBar/components/LogoutLink.tsx
+++ b/src/components/LayoutNavBar/components/LogoutLink.tsx
@@ -11,7 +11,7 @@ export function LogoutLink({ open }: LogoutLinkProps) {
   return (
     <Box className={classes.link} onClick={open}>
       <IconLogout className={classes.linkIcon} stroke={1.5} />
-      <span>Log out</span>
+      <span>ログアウト</span>
     </Box>
   )
 }

--- a/src/components/LayoutNavBar/utils.ts
+++ b/src/components/LayoutNavBar/utils.ts
@@ -8,8 +8,8 @@ import {
 import { Path } from '../../constants'
 
 export const createLinkItems = () => [
-  { path: Path.Day, label: 'Day', icon: IconClockHour9 },
-  { path: Path.Week, label: 'Week', icon: IconBoxMultiple7 },
-  { path: Path.Preset, label: 'Preset', icon: IconAlbum },
-  { path: Path.Settings, label: 'Settings', icon: IconAdjustmentsHorizontal },
+  { path: Path.Day, label: '日別記録', icon: IconClockHour9 },
+  { path: Path.Week, label: '週間レポート', icon: IconBoxMultiple7 },
+  { path: Path.Preset, label: 'プリセット', icon: IconAlbum },
+  { path: Path.Settings, label: '目標設定', icon: IconAdjustmentsHorizontal },
 ]


### PR DESCRIPTION
This pull request focuses on localizing the application by updating UI text to Japanese in various components and tests. The most important changes include modifying navigation labels, button text, and test cases to reflect the new localized strings.

### Localization updates:

* [`src/components/LayoutNavBar/utils.ts`](diffhunk://#diff-4131fbcd2b1b48658ef008ed90500398f974685a9851d62be07625bd68bc2d4bL11-R14): Updated navigation labels to Japanese, including "Day" to "日別記録", "Week" to "週間レポート", "Preset" to "プリセット", and "Settings" to "目標設定".
* [`src/components/LayoutNavBar/components/LogoutLink.tsx`](diffhunk://#diff-29d28a381b6fc43a645701a91298e5f2f8b5d4437f156a3ae299d402ebd2ec9fL14-R14): Changed the "Log out" button text to "ログアウト".

### Test updates for localization:

* [`e2e/tests/settings-page.spec.ts`](diffhunk://#diff-763eae656eb313393d39b89975e06b207b509bcab73f8fb99205c54c37aa08f3L11-R11): Updated test cases to use the Japanese label "目標設定" instead of "Settings" when interacting with the settings page link. [[1]](diffhunk://#diff-763eae656eb313393d39b89975e06b207b509bcab73f8fb99205c54c37aa08f3L11-R11) [[2]](diffhunk://#diff-763eae656eb313393d39b89975e06b207b509bcab73f8fb99205c54c37aa08f3L21-R21)