### PR TITLE
Update page titles to Japanese

### DIFF
--- a/src/pages/day.tsx
+++ b/src/pages/day.tsx
@@ -7,7 +7,7 @@ import { DatePickerCard } from '../features/date-picker-card'
 
 export default function Day() {
   return (
-    <Layout title="Day">
+    <Layout title="日別">
       <Box maw={300} mb={30}>
         <DatePickerCard />
       </Box>

--- a/src/pages/preset.tsx
+++ b/src/pages/preset.tsx
@@ -6,7 +6,7 @@ import { PresetNutritions } from '../features/preset-nutritions'
 
 export default function Preset() {
   return (
-    <Layout title="Preset">
+    <Layout title="プリセット">
       <Box maw={700} mb={30}>
         <PresetNutritions />
       </Box>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -5,7 +5,7 @@ import { DailyGoal } from '../features/daily-goal'
 
 export default function Settings() {
   return (
-    <Layout title="Settings">
+    <Layout title="目標設定">
       <Box maw={400} mb={20}>
         <DailyGoal />
       </Box>

--- a/src/pages/week.tsx
+++ b/src/pages/week.tsx
@@ -7,7 +7,7 @@ import { WeeklyNutritions } from '../features/weekly-nutritions'
 
 export default function Week() {
   return (
-    <Layout title="Week">
+    <Layout title="週間">
       <Box maw={300} mb={30}>
         <DatePickerCard />
       </Box>


### PR DESCRIPTION
## Summary
- localize Layout titles for Day, Week, Preset and Settings pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc1ed496083279542a85e3922b12c