### PR TITLE
feat: add preset application functionality to meal form

### DIFF
--- a/src/components/MealFormButtons/MealFormButtons.tsx
+++ b/src/components/MealFormButtons/MealFormButtons.tsx
@@ -3,20 +3,40 @@ import { Button, Center } from '@mantine/core'
 type MealFormButtonsProps = {
   onAdd: () => void
   onSave: () => Promise<void>
+  onApplyPreset?: () => Promise<void>
   isSaveButtonDisabled: boolean
+  isApplyPresetButtonDisabled?: boolean
 }
 
 export function MealFormButtons({
   onAdd,
   onSave,
+  onApplyPreset,
   isSaveButtonDisabled,
+  isApplyPresetButtonDisabled,
 }: MealFormButtonsProps) {
   return (
     <Center mt="xl">
+      {onApplyPreset && (
+        <Button
+          mr="md"
+          variant="outline"
+          color="blue"
+          onClick={onApplyPreset}
+          disabled={isApplyPresetButtonDisabled}
+        >
+          プリセット適用
+        </Button>
+      )}
       <Button mr="md" onClick={onAdd}>
         追加
       </Button>
-      <Button color="teal" onClick={onSave} disabled={isSaveButtonDisabled}>
+      <Button
+        mr="md"
+        color="teal"
+        onClick={onSave}
+        disabled={isSaveButtonDisabled}
+      >
         保存
       </Button>
     </Center>

--- a/src/features/daily-meal-form/components/DailyMealFormAccordionItem.tsx
+++ b/src/features/daily-meal-form/components/DailyMealFormAccordionItem.tsx
@@ -2,6 +2,7 @@ import { Accordion } from '@mantine/core'
 import { Notifications } from '@mantine/notifications'
 import { useState } from 'react'
 
+import { fetchUserMealPreset } from '../../../api/user-meal-preset'
 import { MealFormButtons } from '../../../components/MealFormButtons'
 import { MealIcon } from '../../../components/MealIcon'
 import { NOTIFICATION_DISPLAY_DURATION_MS } from '../../../constants'
@@ -11,7 +12,12 @@ import { createStringFromDate, showNotification } from '../../../utils'
 import { MEAL_CATEGORY_LABELS } from '../constants'
 import { useDailyMealRecordStore } from '../stores'
 import { FormsType } from '../types'
-import { createFoodInitialValues, saveAndSetDailyMealRecord } from '../utils'
+import {
+  convertPresetToFormData,
+  createFoodInitialValues,
+  getPresetFoodsForCategory,
+  saveAndSetDailyMealRecord,
+} from '../utils'
 import { DailyMealFormContent } from './DailyMealFormContent'
 
 type MealFormAccordionItemProps = {
@@ -24,6 +30,8 @@ export function DailyMealFormAccordionItem({
   forms,
 }: MealFormAccordionItemProps) {
   const [isSaveButtonDisabled, setIsSaveButtonDisabled] = useState(false)
+  const [isApplyPresetButtonDisabled, setIsApplyPresetButtonDisabled] =
+    useState(false)
   const { dailyMealRecord, setDailyMealRecord } = useDailyMealRecordStore()
   const { currentDate } = useCurrentDateStore()
   const currentDateString = createStringFromDate(currentDate)
@@ -56,6 +64,41 @@ export function DailyMealFormAccordionItem({
     }
   }
 
+  const handleApplyPreset = async () => {
+    setIsApplyPresetButtonDisabled(true)
+    try {
+      const userMealPreset = await fetchUserMealPreset()
+      const presetFoods = getPresetFoodsForCategory(
+        userMealPreset,
+        mealCategoryName
+      )
+      if (presetFoods.length > 0) {
+        const formData = convertPresetToFormData(presetFoods)
+        forms.setFieldValue(mealCategoryName, formData)
+        showNotification(
+          'Day',
+          `${MEAL_CATEGORY_LABELS[mealCategoryName]}のプリセットを適用しました`,
+          'success',
+          setIsApplyPresetButtonDisabled
+        )
+      } else {
+        showNotification(
+          'Day',
+          `${MEAL_CATEGORY_LABELS[mealCategoryName]}のプリセットが見つかりません`,
+          'error',
+          setIsApplyPresetButtonDisabled
+        )
+      }
+    } catch (err) {
+      showNotification(
+        'Day',
+        `プリセットの適用に失敗しました`,
+        'error',
+        setIsApplyPresetButtonDisabled
+      )
+    }
+  }
+
   return (
     <Accordion.Item value={mealCategoryName}>
       <Accordion.Control
@@ -72,7 +115,9 @@ export function DailyMealFormAccordionItem({
         <MealFormButtons
           onAdd={handleAdd}
           onSave={handleSave}
+          onApplyPreset={handleApplyPreset}
           isSaveButtonDisabled={isSaveButtonDisabled}
+          isApplyPresetButtonDisabled={isApplyPresetButtonDisabled}
         />
       </Accordion.Panel>
 

--- a/src/features/daily-meal-form/utils.ts
+++ b/src/features/daily-meal-form/utils.ts
@@ -9,6 +9,7 @@ import {
   ListDailyMealRecordsQueryVariables,
   UpdateDailyMealRecordInput,
   UpdateDailyMealRecordMutationVariables,
+  UserMealPreset,
 } from '../../API'
 import {
   addDailyMealRecord,
@@ -231,4 +232,47 @@ const normalizeDailyMealRecordFoods = (forms: FormsType) => {
     dinner: normalizeCategory(MealCategoryName.DINNER),
     snack: normalizeCategory(MealCategoryName.SNACK),
   }
+}
+
+/**
+ * Converts preset food items to form field format.
+ *
+ * @param presetFoods - The preset food items to convert.
+ * @returns The converted form field data.
+ */
+export const convertPresetToFormData = (
+  presetFoods: FoodItem[]
+): FormField[] => {
+  return presetFoods.map((presetFood) => ({
+    id: createId(),
+    name: presetFood.name,
+    calories: presetFood.calories?.toString() || '',
+    protein: presetFood.protein?.toString() || '',
+    carbohydrates: presetFood.carbohydrates?.toString() || '',
+    fat: presetFood.fat?.toString() || '',
+  }))
+}
+
+/**
+ * Gets preset foods for a specific meal category.
+ *
+ * @param userMealPreset - The user meal preset object.
+ * @param mealCategoryName - The meal category name.
+ * @returns The preset foods for the category or empty array.
+ */
+export const getPresetFoodsForCategory = (
+  userMealPreset: UserMealPreset | null,
+  mealCategoryName: MealCategoryName
+): FoodItem[] => {
+  if (!userMealPreset) {
+    return []
+  }
+
+  const categoryKey = mealCategoryName.toLowerCase() as keyof Pick<
+    UserMealPreset,
+    'breakfast' | 'lunch' | 'dinner' | 'snack'
+  >
+  const presetFoods = userMealPreset[categoryKey] as FoodItem[] | null
+
+  return presetFoods || []
 }


### PR DESCRIPTION
This pull request introduces functionality to apply user meal presets in the daily meal form. The changes include updates to the `MealFormButtons` component, the `DailyMealFormAccordionItem` component, and utility functions for handling preset data. Below is a summary of the most important changes:

### New Feature: Apply User Meal Presets

* **`MealFormButtons` Component**:
  - Added optional props `onApplyPreset` and `isApplyPresetButtonDisabled` to handle the new "Apply Preset" button. The button is conditionally rendered and triggers the `onApplyPreset` callback when clicked.

* **`DailyMealFormAccordionItem` Component**:
  - Introduced a new state variable, `isApplyPresetButtonDisabled`, to manage the disabled state of the "Apply Preset" button.
  - Added the `handleApplyPreset` function to fetch and apply user meal presets for a specific meal category. This function includes error handling and user notifications for success or failure.
  - Updated the `MealFormButtons` usage to pass the new `onApplyPreset` and `isApplyPresetButtonDisabled` props.

### Utility Enhancements for Preset Handling

* **Utility Functions**:
  - Added `convertPresetToFormData` to transform preset food items into the format required by the form fields.
  - Added `getPresetFoodsForCategory` to retrieve preset foods for a specific meal category from the user meal preset object.

### Dependency Updates

* **Imports**:
  - Imported `fetchUserMealPreset` in `DailyMealFormAccordionItem` to fetch user meal presets from the API.
  - Added `UserMealPreset` type to the utility file for type safety when handling preset data.