### PR TITLE
Make header title link to daily page

### DIFF
--- a/src/components/LayoutHeader/LayoutHeader.module.css
+++ b/src/components/LayoutHeader/LayoutHeader.module.css
@@ -6,3 +6,9 @@
   height: 30px;
   flex-shrink: 0;
 }
+
+.title {
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}

--- a/src/components/LayoutHeader/LayoutHeader.tsx
+++ b/src/components/LayoutHeader/LayoutHeader.tsx
@@ -1,6 +1,8 @@
 import { Box, Burger, Image, Title, useMantineTheme } from '@mantine/core'
+import Link from 'next/link'
 import { Dispatch, SetStateAction } from 'react'
 
+import { Path } from '../../constants'
 import styles from './LayoutHeader.module.css'
 
 type LayoutHeaderProps = {
@@ -27,9 +29,11 @@ export function LayoutHeader({
       <Box className={styles.iconContainer}>
         <Image src="/favicon.ico" alt="App Icon" />
       </Box>
-      <Title order={3} w={800} fw={200}>
-        Tracking Your Daily Diet
-      </Title>
+      <Link href={Path.Day} className={styles.title}>
+        <Title order={3} w={800} fw={200}>
+          Tracking Your Daily Diet
+        </Title>
+      </Link>
     </Box>
   )
 }


### PR DESCRIPTION
## Summary
- make the header title link to the daily view
- style the header title link to appear consistent

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac529ac720832799b66d55a608d4f8