### PR TITLE
Translate goal settings notification

### DIFF
--- a/src/features/daily-goal/components/DailyGoal.tsx
+++ b/src/features/daily-goal/components/DailyGoal.tsx
@@ -35,8 +35,8 @@ export function DailyGoal() {
 
   const handleSuccess = () => {
     notifications.show({
-      title: 'Saved!',
-      message: 'Settings',
+      title: '目標設定',
+      message: '保存しました',
       color: 'green',
       icon: <IconCheck />,
     })
@@ -48,8 +48,8 @@ export function DailyGoal() {
 
   const handleError = () => {
     notifications.show({
-      title: 'Error!',
-      message: 'Settings',
+      title: '目標設定',
+      message: '保存に失敗しました',
       color: 'red',
       icon: <IconX />,
     })


### PR DESCRIPTION
## Summary
- Use "目標設定" as the notification title when saving daily goals for clearer context

## Testing
- `npm test` *(fails: command not found: npm; Node.js missing)*
- `npm run lint` *(fails: command not found: npm; Node.js missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac52e6c8fc8327a30abaeb584806bc