### PR TITLE
feat: guest login

### DIFF
--- a/src/api/daily-goal/add-daily-goal.ts
+++ b/src/api/daily-goal/add-daily-goal.ts
@@ -7,10 +7,14 @@ import {
 import { createDailyGoal } from '../../graphql/mutations'
 import { DailyGoalState } from '../../stores'
 import { client } from '../../utils/amplifyClient'
+import { guestAddDailyGoal } from '../guest/guest-storage'
+import { getGuestModeFlag } from '../guest/guestModeFlag'
 
 export const addDailyGoal = async (
   variables: CreateDailyGoalMutationVariables,
 ) => {
+  if (getGuestModeFlag()) return guestAddDailyGoal(variables)
+
   try {
     const { data } = await client.graphql<
       GraphQLQuery<CreateDailyGoalMutation>

--- a/src/api/daily-goal/fetch-daily-goal.ts
+++ b/src/api/daily-goal/fetch-daily-goal.ts
@@ -3,8 +3,12 @@ import { GraphQLQuery } from '@aws-amplify/api'
 import { ListDailyGoalsQuery } from '../../API'
 import { listDailyGoals } from '../../graphql/queries'
 import { client } from '../../utils/amplifyClient'
+import { guestFetchDailyGoal } from '../guest/guest-storage'
+import { getGuestModeFlag } from '../guest/guestModeFlag'
 
 export const fetchDailyGoal = async () => {
+  if (getGuestModeFlag()) return guestFetchDailyGoal()
+
   try {
     const { data } = await client.graphql<GraphQLQuery<ListDailyGoalsQuery>>({
       query: listDailyGoals,

--- a/src/api/daily-goal/upd-daily-goal.ts
+++ b/src/api/daily-goal/upd-daily-goal.ts
@@ -7,10 +7,14 @@ import {
 import { updateDailyGoal } from '../../graphql/mutations'
 import { DailyGoalState } from '../../stores'
 import { client } from '../../utils/amplifyClient'
+import { guestUpdDailyGoal } from '../guest/guest-storage'
+import { getGuestModeFlag } from '../guest/guestModeFlag'
 
 export const updDailyGoal = async (
   variables: UpdateDailyGoalMutationVariables,
 ) => {
+  if (getGuestModeFlag()) return guestUpdDailyGoal(variables)
+
   try {
     const { data } = await client.graphql<
       GraphQLQuery<UpdateDailyGoalMutation>

--- a/src/api/daily-meal-record/add-daily-meal-record.ts
+++ b/src/api/daily-meal-record/add-daily-meal-record.ts
@@ -7,6 +7,8 @@ import {
 } from '../../API'
 import { createDailyMealRecord } from '../../graphql/mutations'
 import { client } from '../../utils/amplifyClient'
+import { guestAddDailyMealRecord } from '../guest/guest-storage'
+import { getGuestModeFlag } from '../guest/guestModeFlag'
 
 /**
  * Creates a new daily meal record.
@@ -17,6 +19,8 @@ import { client } from '../../utils/amplifyClient'
 export const addDailyMealRecord = async (
   variables: CreateDailyMealRecordMutationVariables,
 ): Promise<DailyMealRecord> => {
+  if (getGuestModeFlag()) return guestAddDailyMealRecord(variables)
+
   try {
     const { data } = await client.graphql<
       GraphQLQuery<CreateDailyMealRecordMutation>

--- a/src/api/daily-meal-record/fetch-daily-meal-records.ts
+++ b/src/api/daily-meal-record/fetch-daily-meal-records.ts
@@ -7,6 +7,8 @@ import {
 } from '../../API'
 import { listDailyMealRecords } from '../../graphql/queries'
 import { client } from '../../utils/amplifyClient'
+import { guestFetchDailyMealRecords } from '../guest/guest-storage'
+import { getGuestModeFlag } from '../guest/guestModeFlag'
 import { fetchDailyMealRecordWithFoods } from './fetch-daily-meal-record'
 
 /**
@@ -18,6 +20,8 @@ import { fetchDailyMealRecordWithFoods } from './fetch-daily-meal-record'
 export const fetchDailyMealRecords = async (
   variables?: ListDailyMealRecordsQueryVariables,
 ): Promise<DailyMealRecord[]> => {
+  if (getGuestModeFlag()) return guestFetchDailyMealRecords(variables)
+
   try {
     const { data } = await client.graphql<
       GraphQLQuery<ListDailyMealRecordsQuery>

--- a/src/api/daily-meal-record/upd-daily-meal-record.ts
+++ b/src/api/daily-meal-record/upd-daily-meal-record.ts
@@ -7,6 +7,8 @@ import {
 } from '../../API'
 import { updateDailyMealRecord } from '../../graphql/mutations'
 import { client } from '../../utils/amplifyClient'
+import { guestUpdDailyMealRecord } from '../guest/guest-storage'
+import { getGuestModeFlag } from '../guest/guestModeFlag'
 
 /**
  * Updates an existing daily meal record.
@@ -17,6 +19,8 @@ import { client } from '../../utils/amplifyClient'
 export const updDailyMealRecord = async (
   variables: UpdateDailyMealRecordMutationVariables,
 ): Promise<DailyMealRecord> => {
+  if (getGuestModeFlag()) return guestUpdDailyMealRecord(variables)
+
   try {
     const { data } = await client.graphql<
       GraphQLQuery<UpdateDailyMealRecordMutation>

--- a/src/api/guest/guest-storage.ts
+++ b/src/api/guest/guest-storage.ts
@@ -1,0 +1,219 @@
+import {
+  CreateDailyGoalMutationVariables,
+  CreateDailyMealRecordMutationVariables,
+  CreateUserMealPresetMutationVariables,
+  DailyGoal,
+  DailyMealRecord,
+  ListDailyMealRecordsQueryVariables,
+  UpdateDailyGoalMutationVariables,
+  UpdateDailyMealRecordMutationVariables,
+  UpdateUserMealPresetMutationVariables,
+  UserMealPreset,
+} from '../../API'
+
+const KEYS = {
+  DAILY_GOAL: 'guest_daily_goal',
+  MEAL_RECORDS: 'guest_meal_records',
+  MEAL_PRESET: 'guest_meal_preset',
+  MODE: 'guest_mode',
+} as const
+
+const now = () => new Date().toISOString()
+const nowMs = () => Date.now()
+
+// ─── DailyGoal ───────────────────────────────────────────────────────────────
+
+export const guestFetchDailyGoal = async (): Promise<DailyGoal | undefined> => {
+  const raw = localStorage.getItem(KEYS.DAILY_GOAL)
+  return raw ? (JSON.parse(raw) as DailyGoal) : undefined
+}
+
+export const guestAddDailyGoal = async (
+  variables: CreateDailyGoalMutationVariables,
+): Promise<DailyGoal> => {
+  const { input } = variables
+  const record: DailyGoal = {
+    __typename: 'DailyGoal',
+    id: crypto.randomUUID(),
+    calories: input.calories ?? null,
+    protein: input.protein ?? null,
+    carbohydrates: input.carbohydrates ?? null,
+    fat: input.fat ?? null,
+    createdAt: now(),
+    updatedAt: now(),
+    _version: 1,
+    _lastChangedAt: nowMs(),
+  }
+  localStorage.setItem(KEYS.DAILY_GOAL, JSON.stringify(record))
+  return record
+}
+
+export const guestUpdDailyGoal = async (
+  variables: UpdateDailyGoalMutationVariables,
+): Promise<DailyGoal> => {
+  const { input } = variables
+  const existing = await guestFetchDailyGoal()
+  if (!existing) throw new Error('Guest daily goal not found')
+
+  const updated: DailyGoal = {
+    ...existing,
+    calories: input.calories !== undefined ? input.calories : existing.calories,
+    protein: input.protein !== undefined ? input.protein : existing.protein,
+    carbohydrates:
+      input.carbohydrates !== undefined
+        ? input.carbohydrates
+        : existing.carbohydrates,
+    fat: input.fat !== undefined ? input.fat : existing.fat,
+    updatedAt: now(),
+    _version: existing._version + 1,
+    _lastChangedAt: nowMs(),
+  }
+  localStorage.setItem(KEYS.DAILY_GOAL, JSON.stringify(updated))
+  return updated
+}
+
+// ─── DailyMealRecord ─────────────────────────────────────────────────────────
+
+const loadMealRecords = (): DailyMealRecord[] => {
+  const raw = localStorage.getItem(KEYS.MEAL_RECORDS)
+  return raw ? (JSON.parse(raw) as DailyMealRecord[]) : []
+}
+
+const saveMealRecords = (records: DailyMealRecord[]) => {
+  localStorage.setItem(KEYS.MEAL_RECORDS, JSON.stringify(records))
+}
+
+export const guestFetchDailyMealRecords = async (
+  variables?: ListDailyMealRecordsQueryVariables,
+): Promise<DailyMealRecord[]> => {
+  const records = loadMealRecords()
+  const dateFilter = variables?.filter?.date?.eq
+  if (!dateFilter) return records
+  return records.filter((r) => r.date === dateFilter)
+}
+
+export const guestAddDailyMealRecord = async (
+  variables: CreateDailyMealRecordMutationVariables,
+): Promise<DailyMealRecord> => {
+  const { input } = variables
+  const record: DailyMealRecord = {
+    __typename: 'DailyMealRecord',
+    id: crypto.randomUUID(),
+    date: input.date,
+    breakfast: (input.breakfast as DailyMealRecord['breakfast']) ?? null,
+    lunch: (input.lunch as DailyMealRecord['lunch']) ?? null,
+    dinner: (input.dinner as DailyMealRecord['dinner']) ?? null,
+    snack: (input.snack as DailyMealRecord['snack']) ?? null,
+    createdAt: now(),
+    updatedAt: now(),
+    _version: 1,
+    _lastChangedAt: nowMs(),
+  }
+  const records = loadMealRecords()
+  records.push(record)
+  saveMealRecords(records)
+  return record
+}
+
+export const guestUpdDailyMealRecord = async (
+  variables: UpdateDailyMealRecordMutationVariables,
+): Promise<DailyMealRecord> => {
+  const { input } = variables
+  const records = loadMealRecords()
+  const index = records.findIndex((r) => r.id === input.id)
+  if (index === -1) throw new Error('Guest meal record not found')
+
+  const existing = records[index]
+  const updated: DailyMealRecord = {
+    ...existing,
+    breakfast:
+      input.breakfast !== undefined
+        ? (input.breakfast as DailyMealRecord['breakfast'])
+        : existing.breakfast,
+    lunch:
+      input.lunch !== undefined
+        ? (input.lunch as DailyMealRecord['lunch'])
+        : existing.lunch,
+    dinner:
+      input.dinner !== undefined
+        ? (input.dinner as DailyMealRecord['dinner'])
+        : existing.dinner,
+    snack:
+      input.snack !== undefined
+        ? (input.snack as DailyMealRecord['snack'])
+        : existing.snack,
+    updatedAt: now(),
+    _version: existing._version + 1,
+    _lastChangedAt: nowMs(),
+  }
+  records[index] = updated
+  saveMealRecords(records)
+  return updated
+}
+
+// ─── UserMealPreset ──────────────────────────────────────────────────────────
+
+export const guestFetchUserMealPreset =
+  async (): Promise<UserMealPreset | null> => {
+    const raw = localStorage.getItem(KEYS.MEAL_PRESET)
+    return raw ? (JSON.parse(raw) as UserMealPreset) : null
+  }
+
+export const guestAddUserMealPreset = async (
+  variables: CreateUserMealPresetMutationVariables,
+): Promise<UserMealPreset> => {
+  const { input } = variables
+  const record: UserMealPreset = {
+    __typename: 'UserMealPreset',
+    id: crypto.randomUUID(),
+    breakfast: (input.breakfast as UserMealPreset['breakfast']) ?? null,
+    lunch: (input.lunch as UserMealPreset['lunch']) ?? null,
+    dinner: (input.dinner as UserMealPreset['dinner']) ?? null,
+    snack: (input.snack as UserMealPreset['snack']) ?? null,
+    createdAt: now(),
+    updatedAt: now(),
+    _version: 1,
+    _lastChangedAt: nowMs(),
+  }
+  localStorage.setItem(KEYS.MEAL_PRESET, JSON.stringify(record))
+  return record
+}
+
+export const guestUpdUserMealPreset = async (
+  variables: UpdateUserMealPresetMutationVariables,
+): Promise<UserMealPreset> => {
+  const existing = await guestFetchUserMealPreset()
+  if (!existing) throw new Error('Guest meal preset not found')
+
+  const { input } = variables
+  const updated: UserMealPreset = {
+    ...existing,
+    breakfast:
+      input.breakfast !== undefined
+        ? (input.breakfast as UserMealPreset['breakfast'])
+        : existing.breakfast,
+    lunch:
+      input.lunch !== undefined
+        ? (input.lunch as UserMealPreset['lunch'])
+        : existing.lunch,
+    dinner:
+      input.dinner !== undefined
+        ? (input.dinner as UserMealPreset['dinner'])
+        : existing.dinner,
+    snack:
+      input.snack !== undefined
+        ? (input.snack as UserMealPreset['snack'])
+        : existing.snack,
+    updatedAt: now(),
+    _version: existing._version + 1,
+    _lastChangedAt: nowMs(),
+  }
+  localStorage.setItem(KEYS.MEAL_PRESET, JSON.stringify(updated))
+  return updated
+}
+
+// ─── Cleanup ─────────────────────────────────────────────────────────────────
+
+export const clearAllGuestData = () => {
+  Object.values(KEYS).forEach((key) => localStorage.removeItem(key))
+}

--- a/src/api/guest/guestModeFlag.ts
+++ b/src/api/guest/guestModeFlag.ts
@@ -1,0 +1,7 @@
+let _isGuestMode = false
+
+export const setGuestModeFlag = (v: boolean) => {
+  _isGuestMode = v
+}
+
+export const getGuestModeFlag = () => _isGuestMode

--- a/src/api/user-meal-preset/add-user-meal-preset.ts
+++ b/src/api/user-meal-preset/add-user-meal-preset.ts
@@ -7,6 +7,8 @@ import {
 } from '../../API'
 import { createUserMealPreset } from '../../graphql/mutations'
 import { client } from '../../utils/amplifyClient'
+import { guestAddUserMealPreset } from '../guest/guest-storage'
+import { getGuestModeFlag } from '../guest/guestModeFlag'
 
 /**
  * Creates a new user meal preset.
@@ -17,6 +19,8 @@ import { client } from '../../utils/amplifyClient'
 export const addUserMealPreset = async (
   variables: CreateUserMealPresetMutationVariables,
 ): Promise<UserMealPreset> => {
+  if (getGuestModeFlag()) return guestAddUserMealPreset(variables)
+
   try {
     const { data } = await client.graphql<
       GraphQLQuery<CreateUserMealPresetMutation>

--- a/src/api/user-meal-preset/fetch-user-meal-preset.ts
+++ b/src/api/user-meal-preset/fetch-user-meal-preset.ts
@@ -7,6 +7,8 @@ import {
 } from '../../API'
 import { listUserMealPresets } from '../../graphql/queries'
 import { client } from '../../utils/amplifyClient'
+import { guestFetchUserMealPreset } from '../guest/guest-storage'
+import { getGuestModeFlag } from '../guest/guestModeFlag'
 import { fetchUserMealPresetWithFood } from './fetch-user-meal-preset-with-food'
 
 /**
@@ -19,6 +21,8 @@ import { fetchUserMealPresetWithFood } from './fetch-user-meal-preset-with-food'
 export const fetchUserMealPreset = async (
   variables?: ListUserMealPresetsQueryVariables,
 ): Promise<UserMealPreset | null> => {
+  if (getGuestModeFlag()) return guestFetchUserMealPreset()
+
   try {
     const { data } = await client.graphql<
       GraphQLQuery<ListUserMealPresetsQuery>

--- a/src/api/user-meal-preset/upd-user-meal-preset.ts
+++ b/src/api/user-meal-preset/upd-user-meal-preset.ts
@@ -7,6 +7,8 @@ import {
 } from '../../API'
 import { updateUserMealPreset } from '../../graphql/mutations'
 import { client } from '../../utils/amplifyClient'
+import { guestUpdUserMealPreset } from '../guest/guest-storage'
+import { getGuestModeFlag } from '../guest/guestModeFlag'
 
 /**
  * Updates an existing user meal preset.
@@ -17,6 +19,8 @@ import { client } from '../../utils/amplifyClient'
 export const updUserMealPreset = async (
   variables: UpdateUserMealPresetMutationVariables,
 ): Promise<UserMealPreset> => {
+  if (getGuestModeFlag()) return guestUpdUserMealPreset(variables)
+
   try {
     const { data } = await client.graphql<
       GraphQLQuery<UpdateUserMealPresetMutation>

--- a/src/components/LandingPage/components/HeroSection.tsx
+++ b/src/components/LandingPage/components/HeroSection.tsx
@@ -4,9 +4,10 @@ import classes from '../styles/HeroSection.module.css'
 
 type HeroSectionProps = {
   open: () => void
+  onGuestLogin: () => void
 }
 
-export function HeroSection({ open }: HeroSectionProps) {
+export function HeroSection({ open, onGuestLogin }: HeroSectionProps) {
   return (
     <Stack align="center" gap="xl" m={20}>
       <Text
@@ -31,6 +32,10 @@ export function HeroSection({ open }: HeroSectionProps) {
         onClick={open}
       >
         無料で始める
+      </Button>
+
+      <Button size="md" variant="subtle" color="teal" onClick={onGuestLogin}>
+        ゲストとして試す
       </Button>
     </Stack>
   )

--- a/src/components/LandingPage/components/LandingPage.tsx
+++ b/src/components/LandingPage/components/LandingPage.tsx
@@ -1,6 +1,7 @@
 import { Container, Stack } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 
+import { useGuestModeStore } from '../../../stores'
 import { AuthenticatorModal } from '../../AuthenticatorModal'
 import classes from '../styles/LandingPage.module.css'
 import { AlertMessage } from './AlertMessage'
@@ -9,12 +10,13 @@ import { HeroSection } from './HeroSection'
 
 export function LandingPage() {
   const [opened, { open, close }] = useDisclosure(false)
+  const { enterGuestMode } = useGuestModeStore()
 
   return (
     <div className={classes.wrapper}>
       <Container size="xl" className={classes.inner}>
         <Stack gap={30}>
-          <HeroSection open={open} />
+          <HeroSection open={open} onGuestLogin={enterGuestMode} />
           <FeatureSection />
           <AlertMessage />
         </Stack>

--- a/src/components/LayoutNavBar/components/LayoutNavBar.tsx
+++ b/src/components/LayoutNavBar/components/LayoutNavBar.tsx
@@ -1,25 +1,41 @@
-import { Box } from '@mantine/core'
+import { Badge, Box } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
+import { IconUserOff } from '@tabler/icons-react'
 
+import { useGuestModeStore } from '../../../stores'
 import classes from '../styles/LayoutNavBar.module.css'
+import navLinkClasses from '../styles/LayoutNavBarLinks.module.css'
 import { LayoutNavBarLinks } from './LayoutNavBarLinks'
 import { LogoutLink } from './LogoutLink'
 import { LogoutModal } from './LogoutModal'
 
 export function LayoutNavBar() {
   const [opened, { open, close }] = useDisclosure(false)
+  const { isGuestMode, exitGuestMode } = useGuestModeStore()
 
   return (
     <nav className={classes.navbar}>
       <Box className={classes.navbarMain}>
+        {isGuestMode && (
+          <Badge color="teal" variant="light" mb="sm" w="100%">
+            ゲストモード
+          </Badge>
+        )}
         <LayoutNavBarLinks />
       </Box>
 
       <Box className={classes.footer}>
-        <LogoutLink open={open} />
+        {isGuestMode ? (
+          <Box className={navLinkClasses.link} onClick={exitGuestMode}>
+            <IconUserOff className={navLinkClasses.linkIcon} stroke={1.5} />
+            <span>ゲスト終了</span>
+          </Box>
+        ) : (
+          <LogoutLink open={open} />
+        )}
       </Box>
 
-      {opened && <LogoutModal opened={opened} close={close} />}
+      {!isGuestMode && opened && <LogoutModal opened={opened} close={close} />}
     </nav>
   )
 }

--- a/src/features/date-picker-card/DatePickerCard.tsx
+++ b/src/features/date-picker-card/DatePickerCard.tsx
@@ -13,7 +13,7 @@ type DatePickerCardProps = {
 }
 
 export function DatePickerCard({
-  disableNavigation = true,
+  disableNavigation = false,
 }: DatePickerCardProps) {
   const currentDate = useCurrentDateStore((state) => state.currentDate)
   const setCurrentDate = useCurrentDateStore((state) => state.setCurrentDate)

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,7 +11,7 @@ import { useEffect } from 'react'
 
 import { LoadingIndicator } from '../components/LoadingIndicator'
 import { Path } from '../constants'
-import { useDailyGoalStore } from '../stores'
+import { useDailyGoalStore, useGuestModeStore } from '../stores'
 import { checkIsLoading, fetchAndSetDailyGoal } from '../utils'
 
 export default function App(props: AppProps) {
@@ -26,11 +26,20 @@ export default function App(props: AppProps) {
 
 function MyApp({ Component, pageProps }: AppProps) {
   const { authStatus } = useAuthenticator((context) => [context.authStatus])
+  const { isGuestMode } = useGuestModeStore()
   const setDailyGoal = useDailyGoalStore((state) => state.setDailyGoal)
   const router = useRouter()
-  const isLoading = checkIsLoading(authStatus, router.pathname)
+  const isLoading = checkIsLoading(authStatus, router.pathname, isGuestMode)
 
   useEffect(() => {
+    if (isGuestMode) {
+      fetchAndSetDailyGoal(setDailyGoal)
+      if (router.pathname === Path.Landingpage) {
+        router.push(Path.Day)
+      }
+      return
+    }
+
     if (authStatus === 'unauthenticated') {
       router.push(Path.Landingpage)
       return
@@ -43,7 +52,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     }
 
     // eslint-disable-next-line
-  }, [authStatus])
+  }, [authStatus, isGuestMode])
 
   return isLoading ? <LoadingIndicator /> : <Component {...pageProps} />
 }

--- a/src/stores/guestMode.ts
+++ b/src/stores/guestMode.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand'
+
+import { clearAllGuestData } from '../api/guest/guest-storage'
+import { setGuestModeFlag } from '../api/guest/guestModeFlag'
+
+export type GuestModeState = {
+  isGuestMode: boolean
+  enterGuestMode: () => void
+  exitGuestMode: () => void
+}
+
+const getInitialGuestMode = (): boolean => {
+  if (typeof window === 'undefined') return false
+  return localStorage.getItem('guest_mode') === 'true'
+}
+
+export const useGuestModeStore = create<GuestModeState>()((set) => {
+  const initialGuestMode = getInitialGuestMode()
+  setGuestModeFlag(initialGuestMode)
+
+  return {
+    isGuestMode: initialGuestMode,
+    enterGuestMode: () => {
+      localStorage.setItem('guest_mode', 'true')
+      setGuestModeFlag(true)
+      set({ isGuestMode: true })
+    },
+    exitGuestMode: () => {
+      clearAllGuestData()
+      setGuestModeFlag(false)
+      set({ isGuestMode: false })
+    },
+  }
+})

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,5 +1,6 @@
 export * from './currentDate'
 export * from './dailyGoal'
+export * from './guestMode'
 export * from './loadingState'
 export * from './nutritionNumbers'
 export * from './presetNutritionNumbers'

--- a/src/utils/checkIsLoading.ts
+++ b/src/utils/checkIsLoading.ts
@@ -1,6 +1,14 @@
 import { Path } from '../constants'
 
-export const checkIsLoading = (authStatus: string, pathname: string) =>
+export const checkIsLoading = (
+  authStatus: string,
+  pathname: string,
+  isGuestMode: boolean,
+) =>
   authStatus === 'configuring' ||
-  (authStatus !== 'unauthenticated' && pathname === Path.Landingpage) ||
-  (authStatus !== 'authenticated' && pathname !== Path.Landingpage)
+  (!isGuestMode &&
+    authStatus !== 'unauthenticated' &&
+    pathname === Path.Landingpage) ||
+  (!isGuestMode &&
+    authStatus !== 'authenticated' &&
+    pathname !== Path.Landingpage)

--- a/src/utils/fetchAndSetDailyGoal.ts
+++ b/src/utils/fetchAndSetDailyGoal.ts
@@ -11,5 +11,7 @@ export const fetchAndSetDailyGoal = async (
   setDailyGoal: DailyGoalState['setDailyGoal'],
 ) => {
   const dailyGoal = await fetchDailyGoal()
-  setDailyGoal(dailyGoal as DailyGoalState['dailyGoal'])
+  if (dailyGoal) {
+    setDailyGoal(dailyGoal as DailyGoalState['dailyGoal'])
+  }
 }


### PR DESCRIPTION
## Summary

- Add guest mode so users can try the app without signing up
- Guest data (daily goal, meal records, meal preset) is persisted in `localStorage` and survives page reloads
- Exiting guest mode clears all guest data and redirects to the landing page

## Implementation

**New files**
- `src/api/guest/guest-storage.ts` — localStorage CRUD for all 3 data models, matching Amplify-generated types
- `src/api/guest/guestModeFlag.ts` — module-level singleton that bridges Zustand state to API functions (which can't use hooks)
- `src/stores/guestMode.ts` — Zustand store initialized synchronously from `localStorage` before first render, preventing a redirect race with Amplify's `authStatus`

**Modified**
- 9 API functions (`fetch/add/upd` × 3 models) — dispatch guard added at the top; callers are unchanged
- `checkIsLoading` — added `isGuestMode` parameter to skip auth-based loading checks for guests
- `_app.tsx` — guest routing branch added to `useEffect`
- `HeroSection` / `LandingPage` — "Try as guest" button that calls `enterGuestMode`
- `LayoutNavBar` — guest mode badge + "Exit guest" button in place of logout
- `fetchAndSetDailyGoal` — null guard added to avoid overwriting the store's safe initial state when no goal is stored yet

## Test plan

- [x] Click "Try as guest" on the landing page → redirected to `/day`
- [x] Add meals → reload → data persists
- [x] Check weekly view — multi-day records display correctly
- [x] Save a preset and goal in `/preset` and `/settings`
- [x] Click "Exit guest" → redirected to landing page, `localStorage` cleared
- [x] Normal Cognito login still works correctly