### PR TITLE
feat: improve visual and responsive UI (plan A)

### DIFF
--- a/src/components/NutritionSummary/components/NutritionRing.tsx
+++ b/src/components/NutritionSummary/components/NutritionRing.tsx
@@ -10,7 +10,7 @@ export function NutritionRing({ name, number, percent, color }: Nutrition) {
   const isSmallMobile = useMediaQuery('(max-width: 30em)')
 
   return (
-    <Grid.Col span={{ base: 3, md: 3 }} key={name}>
+    <Grid.Col span={{ base: 6, sm: 3 }} key={name}>
       <Text fw={200} size={isSmallMobile ? 'xs' : 'sm'}>
         {name}
       </Text>

--- a/src/features/date-picker-card/DatePickerCard.tsx
+++ b/src/features/date-picker-card/DatePickerCard.tsx
@@ -1,8 +1,8 @@
-import { Box, Card, Grid, Text } from '@mantine/core'
+import { Box, Card, Grid, Text, Tooltip } from '@mantine/core'
 import {
+  IconCalendarDot,
   IconChevronLeft,
   IconChevronRight,
-  IconDots,
 } from '@tabler/icons-react'
 
 import { useCurrentDateStore } from '../../stores'
@@ -36,10 +36,9 @@ export function DatePickerCard({
           <Text fw={200} size="xl" ml={8}>
             {currentDate?.toLocaleString('ja-JP', {
               year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-              hour: '2-digit',
-              minute: '2-digit',
+              month: 'long',
+              day: 'numeric',
+              weekday: 'short',
             })}
           </Text>
         </Grid>
@@ -57,9 +56,15 @@ export function DatePickerCard({
               className={classes.button}
             />
           </Box>
-          <Box mr={12} onClick={() => changeCurrentDate('today')}>
-            <IconDots size={20} strokeWidth={0.5} className={classes.button} />
-          </Box>
+          <Tooltip label="今日に移動">
+            <Box mr={12} onClick={() => changeCurrentDate('today')}>
+              <IconCalendarDot
+                size={20}
+                strokeWidth={1}
+                className={classes.button}
+              />
+            </Box>
+          </Tooltip>
           <Box onClick={() => changeCurrentDate(1)}>
             <IconChevronRight
               size={20}


### PR DESCRIPTION
- Fix nutrition rings layout to 2x2 grid on mobile (375px)
- Remove time from date display and add weekday
- Replace dots icon with calendar icon and tooltip for today navigation