### PR TITLE
feat: improve LP content and UI

### DIFF
--- a/src/components/LandingPage/components/AlertMessage.tsx
+++ b/src/components/LandingPage/components/AlertMessage.tsx
@@ -1,10 +1,10 @@
 import { Alert } from '@mantine/core'
-import { IconAlertCircle } from '@tabler/icons-react'
+import { IconRocket } from '@tabler/icons-react'
 
 export function AlertMessage() {
   return (
-    <Alert icon={<IconAlertCircle size={20} />} title="お知らせ" color="red">
-      本アプリケーションは現在開発中です。
+    <Alert icon={<IconRocket size={20} />} title="開発中" color="teal">
+      現在ベータ版として公開中です！
     </Alert>
   )
 }

--- a/src/components/LandingPage/components/FeatureSection.tsx
+++ b/src/components/LandingPage/components/FeatureSection.tsx
@@ -1,32 +1,38 @@
-import { Card, Center, SimpleGrid, Stack, Text } from '@mantine/core'
+import { Card, SimpleGrid, Stack, Text, ThemeIcon, Title } from '@mantine/core'
 import { IconChartBar, IconLeaf, IconUserCircle } from '@tabler/icons-react'
 
 import styles from '../styles/FeatureSection.module.css'
 
 const features = [
   {
-    icon: <IconLeaf size={32} color="teal" />,
+    icon: <IconLeaf size={48} />,
+    color: 'teal' as const,
     title: '食事記録',
-    description: '毎日の食事を簡単に記録',
+    description:
+      'メニューを選ぶだけで毎日の食事をカンタン記録。朝食・昼食・夕食・間食をまとめて管理できます。',
   },
   {
-    icon: <IconChartBar size={32} color="blue" />,
+    icon: <IconChartBar size={48} />,
+    color: 'blue' as const,
     title: 'データ分析',
-    description: 'カロリーと栄養素をグラフで表示',
+    description:
+      'カロリーと栄養素（タンパク質・炭水化物・脂質）をグラフで可視化。週間トレンドもひと目でチェック。',
   },
   {
-    icon: <IconUserCircle size={32} color="orange" />,
+    icon: <IconUserCircle size={48} />,
+    color: 'orange' as const,
     title: 'パーソナライズ',
-    description: '目標を設定し毎日の進捗を管理',
+    description:
+      'あなたの目標カロリーと栄養バランスを設定。毎日の進捗をチャートで確認できます。',
   },
 ]
 
 export function FeatureSection() {
   return (
     <Stack gap="xl" id="features">
-      <Center>
-        <Text size="xl">主な機能</Text>
-      </Center>
+      <Title order={2} size="xl" ta="center" c="dimmed">
+        主な機能
+      </Title>
 
       <SimpleGrid cols={{ base: 1, xs: 3 }} spacing="md" verticalSpacing="md">
         {features.map((feature) => (
@@ -44,10 +50,17 @@ export function FeatureSection() {
               justify="center"
               className={styles.cardContent}
             >
-              {feature.icon}
-              <Text size="lg" fw={500} ta="center">
+              <ThemeIcon
+                size={64}
+                radius="xl"
+                variant="light"
+                color={feature.color}
+              >
+                {feature.icon}
+              </ThemeIcon>
+              <Title order={3} size="lg" fw={500} ta="center">
                 {feature.title}
-              </Text>
+              </Title>
               <Text size="sm" c="dimmed" ta="center">
                 {feature.description}
               </Text>

--- a/src/components/LandingPage/components/HeroSection.tsx
+++ b/src/components/LandingPage/components/HeroSection.tsx
@@ -9,34 +9,52 @@ type HeroSectionProps = {
 
 export function HeroSection({ open, onGuestLogin }: HeroSectionProps) {
   return (
-    <Stack align="center" gap="xl" m={20}>
-      <Text
-        variant="gradient"
-        gradient={{ from: 'teal', to: 'blue', deg: 45 }}
-        className={classes.title}
-        m={20}
-      >
-        健康的な食生活をサポート
-      </Text>
+    <div className={classes.heroWrapper}>
+      <Stack align="center" gap="xl" m={20}>
+        <Text
+          component="h1"
+          variant="gradient"
+          gradient={{ from: 'teal', to: 'blue', deg: 45 }}
+          className={classes.title}
+          m={20}
+        >
+          もう食事管理に悩まない
+        </Text>
 
-      <Text className={classes.description} c="dimmed" ta="center">
-        食事管理を簡単に。
-        <br />
-        カロリーと栄養素を可視化、ダイエットをサポートします。
-      </Text>
+        <Text className={classes.description} c="dimmed" ta="center">
+          毎日の食事をカンタン記録。
+          <br />
+          カロリーと栄養バランスを自動で可視化して、あなたの健康をサポートします。
+        </Text>
 
-      <Button
-        size="lg"
-        variant="gradient"
-        gradient={{ from: 'teal', to: 'blue', deg: 45 }}
-        onClick={open}
-      >
-        無料で始める
-      </Button>
+        <Stack gap={4} align="center">
+          <Button
+            size="lg"
+            variant="gradient"
+            gradient={{ from: 'teal', to: 'blue', deg: 45 }}
+            onClick={open}
+          >
+            無料で始める
+          </Button>
+          <Text size="xs" c="dimmed">
+            アカウント作成で全機能を利用 / クレジットカード不要
+          </Text>
+        </Stack>
 
-      <Button size="md" variant="subtle" color="teal" onClick={onGuestLogin}>
-        ゲストとして試す
-      </Button>
-    </Stack>
+        <Stack gap={4} align="center">
+          <Button
+            size="lg"
+            variant="outline"
+            color="teal"
+            onClick={onGuestLogin}
+          >
+            ゲストとして試す
+          </Button>
+          <Text size="xs" c="dimmed">
+            登録不要で今すぐお試し
+          </Text>
+        </Stack>
+      </Stack>
+    </div>
   )
 }

--- a/src/components/LandingPage/styles/FeatureSection.module.css
+++ b/src/components/LandingPage/styles/FeatureSection.module.css
@@ -1,7 +1,16 @@
 .card {
   display: flex;
   flex-direction: column;
-  height: 250px;
+  min-height: 280px;
+  height: auto;
+  transition:
+    transform 200ms ease,
+    box-shadow 200ms ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--mantine-shadow-md);
 }
 
 .cardContent {

--- a/src/components/LandingPage/styles/HeroSection.module.css
+++ b/src/components/LandingPage/styles/HeroSection.module.css
@@ -1,3 +1,13 @@
+.heroWrapper {
+  background: linear-gradient(
+    180deg,
+    rgba(0, 128, 128, 0.04) 0%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  padding: 60px 0 40px;
+  border-radius: var(--mantine-radius-lg);
+}
+
 .title {
   font-family: 'Hiragino Sans', 'Hiragino Kaku Gothic ProN', sans-serif;
   font-size: 3rem;


### PR DESCRIPTION
- Update hero copy to "もう食事管理に悩まない" for emotional appeal
- Add subtle gradient background to hero section
- Add micro-copy below CTA buttons to lower psychological barrier
- Change guest button from subtle to outline for better visibility
- Expand feature card descriptions to 2-3 lines
- Wrap feature icons in ThemeIcon for visual impact
- Add hover lift effect to feature cards
- Change alert from red/negative to teal/positive tone
- Apply semantic heading tags (h1, h2, h3) to LP sections