### PR TITLE
feat: add duplicate food item button in daily meal form

### DIFF
--- a/src/components/LayoutNavBar/components/LayoutNavBar.tsx
+++ b/src/components/LayoutNavBar/components/LayoutNavBar.tsx
@@ -28,7 +28,7 @@ export function LayoutNavBar() {
         {isGuestMode ? (
           <Box className={navLinkClasses.link} onClick={exitGuestMode}>
             <IconUserOff className={navLinkClasses.linkIcon} stroke={1.5} />
-            <span>ゲスト終了</span>
+            <span>ゲストモード終了</span>
           </Box>
         ) : (
           <LogoutLink open={open} />

--- a/src/features/daily-meal-form/components/DailyMealFormFields.tsx
+++ b/src/features/daily-meal-form/components/DailyMealFormFields.tsx
@@ -1,6 +1,7 @@
 import { ActionIcon, Grid, Group, NumberInput, TextInput } from '@mantine/core'
 import { UseFormReturnType } from '@mantine/form'
-import { IconTrash } from '@tabler/icons-react'
+import { createId } from '@paralleldrive/cuid2'
+import { IconCopy, IconTrash } from '@tabler/icons-react'
 
 import { FormData } from '../types'
 
@@ -16,10 +17,22 @@ export function DailyMealFormFields({
   const getFormItemProps = (index: number, fieldName: string) =>
     form.getInputProps(`${mealCategoryName}.${index}.${fieldName}`)
 
+  const handleCopy = (index: number) => {
+    const original = form.values[mealCategoryName][index]
+    form.insertListItem(
+      mealCategoryName,
+      { ...original, id: createId() },
+      index + 1,
+    )
+  }
+
+  const handleRemove = (index: number) =>
+    form.removeListItem(`${mealCategoryName}`, index)
+
   return form.values?.[mealCategoryName].map((item, index) => (
     <Group key={item.id} mt="xs">
       <Grid align="center">
-        <Grid.Col span={{ base: 12, sm: 3 }}>
+        <Grid.Col span={{ base: 12, sm: 2 }}>
           <TextInput
             placeholder="食品名"
             {...getFormItemProps(index, 'name')}
@@ -64,13 +77,15 @@ export function DailyMealFormFields({
             {...getFormItemProps(index, 'carbohydrates')}
           />
         </Grid.Col>
-        <Grid.Col span={1} mt={2}>
-          <ActionIcon
-            color="red"
-            onClick={() => form.removeListItem(`${mealCategoryName}`, index)}
-          >
-            <IconTrash size={18} />
-          </ActionIcon>
+        <Grid.Col span={2} mt={2}>
+          <Group gap="xs" wrap="nowrap">
+            <ActionIcon color="gray" onClick={() => handleCopy(index)}>
+              <IconCopy size={18} />
+            </ActionIcon>
+            <ActionIcon color="red" onClick={() => handleRemove(index)}>
+              <IconTrash size={18} />
+            </ActionIcon>
+          </Group>
         </Grid.Col>
       </Grid>
     </Group>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
Add a copy button next to the trash button in DailyMealFormFields to duplicate a food item inline with a new id. Also extract removeListItem into handleRemove handler for consistency, and fix moduleResolution to bundler in tsconfig.json.