### PR TITLE
fix: prevent sidebar from overlapping AppShell footer

### DIFF
--- a/src/components/LayoutNavBar/styles/LayoutNavBar.module.css
+++ b/src/components/LayoutNavBar/styles/LayoutNavBar.module.css
@@ -1,5 +1,6 @@
 .navbar {
-  height: 93vh;
+  height: calc(100dvh - rem(60px) - rem(30px));
+  max-height: calc(100dvh - rem(60px) - rem(30px));
   width: rem(300px);
   padding: var(--mantine-spacing-md);
   display: flex;


### PR DESCRIPTION
Replace the navbar's hard-coded 93vh height with
calc(100dvh - 60px - 30px) so it always fits between the AppShell header and footer across desktop and mobile drawer views.