### PR TITLE
refactor: extract page header components and clarify feature/page responsibilities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,9 @@ Kebab-case directories that co-locate components, hooks, utils, types, constants
 - `weekly-calories-chart` — Mantine chart for weekly calorie visualization
 - `daily-nutritions` / `weekly-nutritions` / `preset-nutritions` — nutrition summary displays
 - `date-picker-card` — shared date navigation widget (supports `day` and `week` modes)
+- `preset-header` — section header for the preset page
+
+Internal structure varies by complexity: simple features keep a single component file at the root (e.g. `preset-nutritions/PresetNutritions.tsx`), while features with multiple components use a `components/` subdirectory (e.g. `preset-meal-form/components/`). The exported component name matches the feature name in PascalCase.
 
 ### Pages (`src/pages/`)
 
@@ -75,6 +78,14 @@ Kebab-case directories that co-locate components, hooks, utils, types, constants
 - `/week` — weekly calorie chart and nutrition summary
 - `/preset` — manage meal presets
 - `/settings` — set daily nutrition goals
+
+Pages are composition-only: they import feature components and arrange them. Page files should consist of component calls (e.g. `<PresetNutritions />`), not raw JSX with `Title`/`Text` etc. — if a page needs a section header or label, extract it as a feature.
+
+### Separation of Concerns
+
+- **Feature components own display logic only** — they should not wrap themselves in spacing/layout primitives like `<Box maw={...} mb={...}>`. Layout (max width, margins, gaps) is a page-level concern.
+- **Pages own layout and arrangement** — wrap feature components in `<Box>` with the appropriate `maw` / `mb` / `mt` so the feature stays reusable across different page layouts.
+- **When extracting a component, ask "whose responsibility is this?"** before deciding where it lives. A page-level section header belongs in its own feature (e.g. `preset-header`), not nested inside an unrelated feature like `preset-nutritions`.
 
 ## Conventions
 

--- a/src/features/daily-goal-header/DailyGoalHeader.tsx
+++ b/src/features/daily-goal-header/DailyGoalHeader.tsx
@@ -1,0 +1,9 @@
+import { Title } from '@mantine/core'
+
+export function DailyGoalHeader() {
+  return (
+    <Title order={4} fw={400} c="dimmed" mb="xs">
+      目標を設定します
+    </Title>
+  )
+}

--- a/src/features/daily-goal-header/index.ts
+++ b/src/features/daily-goal-header/index.ts
@@ -1,0 +1,1 @@
+export { DailyGoalHeader } from './DailyGoalHeader'

--- a/src/features/daily-goal/components/DailyGoal.tsx
+++ b/src/features/daily-goal/components/DailyGoal.tsx
@@ -1,4 +1,4 @@
-import { Box, Title } from '@mantine/core'
+import { Box } from '@mantine/core'
 
 import { SaveButton } from '../../../components/SaveButton'
 import { useDailyGoalStore } from '../../../stores'
@@ -19,9 +19,6 @@ export function DailyGoal() {
 
   return (
     <Box>
-      <Title order={4} fw={400} c="dimmed" mb="xs">
-        1日の栄養目標を設定
-      </Title>
       <DailyGoalNumberInput
         label="カロリー (Kcal)"
         placeholder="カロリー"

--- a/src/features/preset-header/PresetHeader.tsx
+++ b/src/features/preset-header/PresetHeader.tsx
@@ -1,0 +1,9 @@
+import { Title } from '@mantine/core'
+
+export function PresetHeader() {
+  return (
+    <Title order={4} fw={400} c="dimmed" mb="xs">
+      プリセットを設定します
+    </Title>
+  )
+}

--- a/src/features/preset-header/index.ts
+++ b/src/features/preset-header/index.ts
@@ -1,0 +1,1 @@
+export { PresetHeader } from './PresetHeader'

--- a/src/pages/preset.tsx
+++ b/src/pages/preset.tsx
@@ -1,12 +1,17 @@
 import { Box } from '@mantine/core'
 
 import { Layout } from '../components/Layout'
+import { PresetHeader } from '../features/preset-header'
 import { PresetMealForm } from '../features/preset-meal-form'
 import { PresetNutritions } from '../features/preset-nutritions'
 
 export default function Preset() {
   return (
     <Layout title="プリセット">
+      <Box maw={300} mb={30}>
+        <PresetHeader />
+      </Box>
+
       <Box maw={700} mb={30}>
         <PresetNutritions />
       </Box>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -2,11 +2,16 @@ import { Box } from '@mantine/core'
 
 import { Layout } from '../components/Layout'
 import { DailyGoal } from '../features/daily-goal'
+import { DailyGoalHeader } from '../features/daily-goal-header'
 
 export default function Settings() {
   return (
     <Layout title="目標設定">
-      <Box maw={400} mb={20}>
+      <Box maw={300} mb={30}>
+        <DailyGoalHeader />
+      </Box>
+
+      <Box maw={400} mb={30}>
         <DailyGoal />
       </Box>
     </Layout>


### PR DESCRIPTION
- Add PresetHeader and DailyGoalHeader as dedicated feature components
- Remove inline Title JSX from PresetNutritions and DailyGoal components
- Move layout (Box wrappers) to page level, keeping features display-only
- Update CLAUDE.md with feature structure rules and separation of concerns