### PR TITLE
feat: add robots meta tag per page for SEO indexing control

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -13,6 +13,7 @@ type LayoutProps = {
   showNavBar?: boolean
   centerContent?: boolean
   fullWidth?: boolean
+  robots?: string
 }
 
 export function Layout({
@@ -21,6 +22,7 @@ export function Layout({
   showNavBar = true,
   centerContent = false,
   fullWidth = false,
+  robots,
 }: LayoutProps) {
   const [navbarOpened, setNavbarOpened] = useState(false)
 
@@ -28,6 +30,7 @@ export function Layout({
     <Box>
       <Head>
         <title>{title}</title>
+        {robots && <meta name="robots" content={robots} />}
       </Head>
 
       <AppShell

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
 export * from './meal-category-name'
 export * from './path'
+export * from './seo'
 export * from './ui-timings'

--- a/src/constants/seo.ts
+++ b/src/constants/seo.ts
@@ -1,0 +1,7 @@
+export const Robots = {
+  IndexFollow: 'index, follow',
+  NoindexFollow: 'noindex, follow',
+  NoindexNofollow: 'noindex, nofollow',
+} as const
+
+export type RobotsValue = (typeof Robots)[keyof typeof Robots]

--- a/src/pages/day.tsx
+++ b/src/pages/day.tsx
@@ -1,13 +1,14 @@
 import { Box } from '@mantine/core'
 
 import { Layout } from '../components/Layout'
+import { Robots } from '../constants'
 import { DailyMealForm } from '../features/daily-meal-form'
 import { DailyNutritions } from '../features/daily-nutritions'
 import { DatePickerCard } from '../features/date-picker-card'
 
 export default function Day() {
   return (
-    <Layout title="日別">
+    <Layout title="日別" robots={Robots.NoindexNofollow}>
       <Box maw={300} mb={30}>
         <DatePickerCard />
       </Box>

--- a/src/pages/landingpage.tsx
+++ b/src/pages/landingpage.tsx
@@ -2,6 +2,7 @@ import Head from 'next/head'
 
 import { LandingPage } from '../components/LandingPage'
 import { Layout } from '../components/Layout'
+import { Robots } from '../constants'
 
 const LP_TITLE = 'Tracking Your Daily Diet — カロリーと栄養素を簡単管理'
 const LP_DESCRIPTION =
@@ -9,7 +10,12 @@ const LP_DESCRIPTION =
 
 export default function Lp() {
   return (
-    <Layout title={LP_TITLE} showNavBar={false} fullWidth>
+    <Layout
+      title={LP_TITLE}
+      showNavBar={false}
+      fullWidth
+      robots={Robots.IndexFollow}
+    >
       <Head>
         <meta name="description" content={LP_DESCRIPTION} />
         <meta property="og:title" content={LP_TITLE} />

--- a/src/pages/preset.tsx
+++ b/src/pages/preset.tsx
@@ -1,13 +1,14 @@
 import { Box } from '@mantine/core'
 
 import { Layout } from '../components/Layout'
+import { Robots } from '../constants'
 import { PresetHeader } from '../features/preset-header'
 import { PresetMealForm } from '../features/preset-meal-form'
 import { PresetNutritions } from '../features/preset-nutritions'
 
 export default function Preset() {
   return (
-    <Layout title="プリセット">
+    <Layout title="プリセット" robots={Robots.NoindexNofollow}>
       <Box maw={300} mb={30}>
         <PresetHeader />
       </Box>

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -1,5 +1,6 @@
 import { Layout } from '../components/Layout'
 import { LegalDocumentMock } from '../components/LegalDocumentMock'
+import { Robots } from '../constants'
 
 const sections = [
   {
@@ -27,7 +28,7 @@ const sections = [
 
 export default function PrivacyPolicy() {
   return (
-    <Layout title="プライバシーポリシー">
+    <Layout title="プライバシーポリシー" robots={Robots.NoindexFollow}>
       <LegalDocumentMock
         title="プライバシーポリシー"
         effectiveDate="2026年1月1日"

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,12 +1,13 @@
 import { Box } from '@mantine/core'
 
 import { Layout } from '../components/Layout'
+import { Robots } from '../constants'
 import { DailyGoal } from '../features/daily-goal'
 import { DailyGoalHeader } from '../features/daily-goal-header'
 
 export default function Settings() {
   return (
-    <Layout title="目標設定">
+    <Layout title="目標設定" robots={Robots.NoindexNofollow}>
       <Box maw={300} mb={30}>
         <DailyGoalHeader />
       </Box>

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -1,5 +1,6 @@
 import { Layout } from '../components/Layout'
 import { LegalDocumentMock } from '../components/LegalDocumentMock'
+import { Robots } from '../constants'
 
 const sections = [
   {
@@ -27,7 +28,7 @@ const sections = [
 
 export default function TermsPage() {
   return (
-    <Layout title="利用規約">
+    <Layout title="利用規約" robots={Robots.NoindexFollow}>
       <LegalDocumentMock
         title="利用規約"
         effectiveDate="2026年1月1日"

--- a/src/pages/week.tsx
+++ b/src/pages/week.tsx
@@ -1,13 +1,14 @@
 import { Box } from '@mantine/core'
 
 import { Layout } from '../components/Layout'
+import { Robots } from '../constants'
 import { DatePickerCard } from '../features/date-picker-card'
 import { WeeklyCaloriesChart } from '../features/weekly-calories-chart'
 import { WeeklyNutritions } from '../features/weekly-nutritions'
 
 export default function Week() {
   return (
-    <Layout title="週間">
+    <Layout title="週間" robots={Robots.NoindexNofollow}>
       <Box maw={300} mb={30}>
         {/* TODO: Remove disableNavigation when paid feature is implemented */}
         <DatePickerCard disableNavigation />


### PR DESCRIPTION
Add a robots prop to the Layout component and specify it explicitly on every page to differentiate indexing policy between public and non-public pages. Authenticated pages, terms, and privacy policy are now marked as noindex so they are excluded from search results.