### PR TITLE
feat: add byOwnerAndDate GSI to DailyMealRecord

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -19,6 +19,12 @@ Represents a user's daily meal record, which includes meals for breakfast, lunch
 """
 type DailyMealRecord @model @auth(rules: [{ allow: owner }]) {
   id: ID!
+  owner: String
+    @index(
+      name: "byOwnerAndDate"
+      sortKeyFields: ["date"]
+      queryField: "dailyMealRecordsByOwnerAndDate"
+    )
   date: AWSDate!
   breakfast: [FoodItem]
   lunch: [FoodItem]


### PR DESCRIPTION
Add an owner @index (partition: owner, sort: date, queryField: dailyMealRecordsByOwnerAndDate) so daily/weekly reads can move from a full-table Scan to an owner-scoped Query.

This change only adds the GSI to the schema. Wiring the API layer to the new query is a follow-up after codegen, once the index is ACTIVE and backfilled on the (Gen1-migrated) tables.

Verified the existing owner attribute on the dev table is stored as {sub}::{username}, reproducible client-side via getCurrentUser().