### PR TITLE
revert: remove byOwnerAndDate GSI from DailyMealRecord

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -1,5 +1,5 @@
 import { defineData } from '@aws-amplify/backend'
-import { aws_dynamodb, aws_iam } from 'aws-cdk-lib'
+import { aws_iam } from 'aws-cdk-lib'
 
 import type { Backend } from '../backend'
 
@@ -19,12 +19,6 @@ Represents a user's daily meal record, which includes meals for breakfast, lunch
 """
 type DailyMealRecord @model @auth(rules: [{ allow: owner }]) {
   id: ID!
-  owner: String
-    @index(
-      name: "byOwnerAndDate"
-      sortKeyFields: ["date"]
-      queryField: "dailyMealRecordsByOwnerAndDate"
-    )
   date: AWSDate!
   breakfast: [FoodItem]
   lunch: [FoodItem]
@@ -95,17 +89,6 @@ export function applyEscapeHatches(backend: Backend) {
       authenticationType: 'AWS_IAM',
     },
   ]
-
-  // The Gen1-migrated DynamoDB tables use on-demand billing (PAY_PER_REQUEST).
-  // When adding a GSI via @index, Amplify may attach provisioned capacity
-  // (Read/WriteCapacityUnits) to the index, which conflicts with the table's
-  // billing mode and fails the deploy:
-  //   "Neither ReadCapacityUnits nor WriteCapacityUnits can be specified for
-  //    index ... when BillingMode is PAY_PER_REQUEST".
-  // Pin the billing mode so the generated GSI is created on-demand too.
-  backend.data.resources.cfnResources.amplifyDynamoDbTables[
-    'DailyMealRecord'
-  ].billingMode = aws_dynamodb.BillingMode.PAY_PER_REQUEST
   backend.auth.resources.authenticatedUserIamRole.addToPrincipalPolicy(
     new aws_iam.PolicyStatement({
       effect: aws_iam.Effect.ALLOW,


### PR DESCRIPTION
Reverts the GSI addition (#276) and the billing-mode escape hatch (#277).

Adding a GSI via @index to the Gen1-migrated DailyMealRecord table is unsafe with the current setup:
- The table uses the IMPORTED_AMPLIFY_TABLE strategy, so it is not in amplifyDynamoDbTables and the billingMode escape hatch cannot reach it (synth fails: Cannot set properties of undefined).
- Deploy also fails on a capacity/billing mismatch (Neither Read/Write CapacityUnits can be specified when BillingMode is PAY_PER_REQUEST).
- More importantly, Gen2 GSI addition on an existing table risks table recreation / data loss (aws-amplify/amplify-backend#2266).

Revert to keep main deployable and prod/dev data safe. Revisit later with an imported-table-safe approach (manual in-place UpdateTable to add the GSI without data loss, then match the schema to the live table).