### PR TITLE
feat: account data purge

### DIFF
--- a/src/api/daily-goal/delete-daily-goal.ts
+++ b/src/api/daily-goal/delete-daily-goal.ts
@@ -1,0 +1,25 @@
+import { GraphQLQuery } from '@aws-amplify/api'
+
+import {
+  DeleteDailyGoalMutation,
+  DeleteDailyGoalMutationVariables,
+} from '../../API'
+import { deleteDailyGoal as deleteDailyGoalMutation } from '../../graphql/mutations'
+import { client } from '../../utils/amplifyClient'
+
+export const deleteDailyGoal = async (
+  variables: DeleteDailyGoalMutationVariables,
+): Promise<void> => {
+  try {
+    await client.graphql<GraphQLQuery<DeleteDailyGoalMutation>>({
+      query: deleteDailyGoalMutation,
+      variables,
+      authMode: 'userPool',
+    })
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('Error deleting DailyGoal:', error)
+    }
+    throw error
+  }
+}

--- a/src/api/daily-goal/fetch-all-daily-goal-ids.ts
+++ b/src/api/daily-goal/fetch-all-daily-goal-ids.ts
@@ -1,0 +1,37 @@
+import { GraphQLQuery } from '@aws-amplify/api'
+
+import { ListDailyGoalsQuery, ListDailyGoalsQueryVariables } from '../../API'
+import { listDailyGoals } from '../../graphql/queries'
+import { client } from '../../utils/amplifyClient'
+
+export const fetchAllDailyGoalIds = async (): Promise<string[]> => {
+  const ids: string[] = []
+  let nextToken: string | null | undefined = undefined
+
+  try {
+    do {
+      const variables: ListDailyGoalsQueryVariables = { nextToken }
+
+      const { data } = await client.graphql<GraphQLQuery<ListDailyGoalsQuery>>({
+        query: listDailyGoals,
+        variables,
+        authMode: 'userPool',
+      })
+
+      const result = data?.listDailyGoals
+      const pageIds = (result?.items ?? [])
+        .filter((goal) => goal !== null)
+        .map((goal) => goal!.id)
+
+      ids.push(...pageIds)
+      nextToken = result?.nextToken
+    } while (nextToken)
+
+    return ids
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('Error fetching all DailyGoal ids:', error)
+    }
+    throw error
+  }
+}

--- a/src/api/daily-goal/index.ts
+++ b/src/api/daily-goal/index.ts
@@ -1,4 +1,5 @@
 export * from './add-daily-goal'
 export * from './delete-daily-goal'
+export * from './fetch-all-daily-goal-ids'
 export * from './fetch-daily-goal'
 export * from './upd-daily-goal'

--- a/src/api/daily-goal/index.ts
+++ b/src/api/daily-goal/index.ts
@@ -1,3 +1,4 @@
 export * from './add-daily-goal'
+export * from './delete-daily-goal'
 export * from './fetch-daily-goal'
 export * from './upd-daily-goal'

--- a/src/api/daily-meal-record/delete-daily-meal-record.ts
+++ b/src/api/daily-meal-record/delete-daily-meal-record.ts
@@ -1,0 +1,31 @@
+import { GraphQLQuery } from '@aws-amplify/api'
+
+import {
+  DeleteDailyMealRecordMutation,
+  DeleteDailyMealRecordMutationVariables,
+} from '../../API'
+import { deleteDailyMealRecord as deleteDailyMealRecordMutation } from '../../graphql/mutations'
+import { client } from '../../utils/amplifyClient'
+
+/**
+ * Deletes a daily meal record.
+ *
+ * @param variables - The variables for deleting a daily meal record.
+ * @returns Nothing. Throws if the deletion fails.
+ */
+export const deleteDailyMealRecord = async (
+  variables: DeleteDailyMealRecordMutationVariables,
+): Promise<void> => {
+  try {
+    await client.graphql<GraphQLQuery<DeleteDailyMealRecordMutation>>({
+      query: deleteDailyMealRecordMutation,
+      variables,
+      authMode: 'userPool',
+    })
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('Error deleting DailyMealRecord:', error)
+    }
+    throw error
+  }
+}

--- a/src/api/daily-meal-record/fetch-all-daily-meal-record-ids.ts
+++ b/src/api/daily-meal-record/fetch-all-daily-meal-record-ids.ts
@@ -1,0 +1,47 @@
+import { GraphQLQuery } from '@aws-amplify/api'
+
+import {
+  ListDailyMealRecordsQuery,
+  ListDailyMealRecordsQueryVariables,
+} from '../../API'
+import { listDailyMealRecords } from '../../graphql/queries'
+import { client } from '../../utils/amplifyClient'
+
+/**
+ * Fetches the IDs of every daily meal record owned by the signed-in user.
+ *
+ * @returns The IDs of all daily meal records across every page.
+ */
+export const fetchAllDailyMealRecordIds = async (): Promise<string[]> => {
+  const ids: string[] = []
+  let nextToken: string | null | undefined = undefined
+
+  try {
+    do {
+      const variables: ListDailyMealRecordsQueryVariables = { nextToken }
+
+      const { data } = await client.graphql<
+        GraphQLQuery<ListDailyMealRecordsQuery>
+      >({
+        query: listDailyMealRecords,
+        variables,
+        authMode: 'userPool',
+      })
+
+      const result = data?.listDailyMealRecords
+      const pageIds = (result?.items ?? [])
+        .filter((record) => record !== null)
+        .map((record) => record!.id)
+
+      ids.push(...pageIds)
+      nextToken = result?.nextToken
+    } while (nextToken)
+
+    return ids
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('Error fetching all DailyMealRecord ids:', error)
+    }
+    throw error
+  }
+}

--- a/src/api/daily-meal-record/index.ts
+++ b/src/api/daily-meal-record/index.ts
@@ -1,5 +1,6 @@
 export { addDailyMealRecord } from './add-daily-meal-record'
 export { deleteDailyMealRecord } from './delete-daily-meal-record'
+export { fetchAllDailyMealRecordIds } from './fetch-all-daily-meal-record-ids'
 export { fetchDailyMealRecordWithFoods } from './fetch-daily-meal-record'
 export { fetchDailyMealRecords } from './fetch-daily-meal-records'
 export { fetchWeeklyDailyMealRecords } from './fetch-weekly-daily-meal-records'

--- a/src/api/daily-meal-record/index.ts
+++ b/src/api/daily-meal-record/index.ts
@@ -1,4 +1,5 @@
 export { addDailyMealRecord } from './add-daily-meal-record'
+export { deleteDailyMealRecord } from './delete-daily-meal-record'
 export { fetchDailyMealRecordWithFoods } from './fetch-daily-meal-record'
 export { fetchDailyMealRecords } from './fetch-daily-meal-records'
 export { fetchWeeklyDailyMealRecords } from './fetch-weekly-daily-meal-records'

--- a/src/api/user-meal-preset/delete-user-meal-preset.ts
+++ b/src/api/user-meal-preset/delete-user-meal-preset.ts
@@ -1,0 +1,31 @@
+import { GraphQLQuery } from '@aws-amplify/api'
+
+import {
+  DeleteUserMealPresetMutation,
+  DeleteUserMealPresetMutationVariables,
+} from '../../API'
+import { deleteUserMealPreset as deleteUserMealPresetMutation } from '../../graphql/mutations'
+import { client } from '../../utils/amplifyClient'
+
+/**
+ * Deletes a user meal preset.
+ *
+ * @param variables - The variables for deleting a user meal preset.
+ * @returns Nothing. Throws if the deletion fails.
+ */
+export const deleteUserMealPreset = async (
+  variables: DeleteUserMealPresetMutationVariables,
+): Promise<void> => {
+  try {
+    await client.graphql<GraphQLQuery<DeleteUserMealPresetMutation>>({
+      query: deleteUserMealPresetMutation,
+      variables,
+      authMode: 'userPool',
+    })
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('Error deleting UserMealPreset:', error)
+    }
+    throw error
+  }
+}

--- a/src/api/user-meal-preset/fetch-all-user-meal-preset-ids.ts
+++ b/src/api/user-meal-preset/fetch-all-user-meal-preset-ids.ts
@@ -1,0 +1,47 @@
+import { GraphQLQuery } from '@aws-amplify/api'
+
+import {
+  ListUserMealPresetsQuery,
+  ListUserMealPresetsQueryVariables,
+} from '../../API'
+import { listUserMealPresets } from '../../graphql/queries'
+import { client } from '../../utils/amplifyClient'
+
+/**
+ * Fetches the IDs of every user meal preset owned by the signed-in user.
+ *
+ * @returns The IDs of all user meal presets across every page.
+ */
+export const fetchAllUserMealPresetIds = async (): Promise<string[]> => {
+  const ids: string[] = []
+  let nextToken: string | null | undefined = undefined
+
+  try {
+    do {
+      const variables: ListUserMealPresetsQueryVariables = { nextToken }
+
+      const { data } = await client.graphql<
+        GraphQLQuery<ListUserMealPresetsQuery>
+      >({
+        query: listUserMealPresets,
+        variables,
+        authMode: 'userPool',
+      })
+
+      const result = data?.listUserMealPresets
+      const pageIds = (result?.items ?? [])
+        .filter((preset) => preset !== null)
+        .map((preset) => preset!.id)
+
+      ids.push(...pageIds)
+      nextToken = result?.nextToken
+    } while (nextToken)
+
+    return ids
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('Error fetching all UserMealPreset ids:', error)
+    }
+    throw error
+  }
+}

--- a/src/api/user-meal-preset/index.ts
+++ b/src/api/user-meal-preset/index.ts
@@ -1,3 +1,4 @@
 export { addUserMealPreset } from './add-user-meal-preset'
+export { deleteUserMealPreset } from './delete-user-meal-preset'
 export { fetchUserMealPreset } from './fetch-user-meal-preset'
 export { updUserMealPreset } from './upd-user-meal-preset'

--- a/src/api/user-meal-preset/index.ts
+++ b/src/api/user-meal-preset/index.ts
@@ -1,4 +1,5 @@
 export { addUserMealPreset } from './add-user-meal-preset'
 export { deleteUserMealPreset } from './delete-user-meal-preset'
+export { fetchAllUserMealPresetIds } from './fetch-all-user-meal-preset-ids'
 export { fetchUserMealPreset } from './fetch-user-meal-preset'
 export { updUserMealPreset } from './upd-user-meal-preset'

--- a/src/features/account-deletion/components/DeleteAllDataButton.tsx
+++ b/src/features/account-deletion/components/DeleteAllDataButton.tsx
@@ -1,0 +1,96 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Group,
+  Modal,
+  Stack,
+  Text,
+} from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
+import { IconAlertTriangle, IconTrash } from '@tabler/icons-react'
+import { useState } from 'react'
+
+import { useDeleteAllData } from '../hooks/useDeleteAllData'
+
+export function DeleteAllDataButton() {
+  const [opened, { open, close }] = useDisclosure(false)
+  const [consented, setConsented] = useState(false)
+  const { deleteStatus, handleDelete } = useDeleteAllData()
+
+  const isDeleting = deleteStatus === 'loading'
+
+  const closeModal = () => {
+    if (isDeleting) return
+    close()
+    setConsented(false)
+  }
+
+  const onConfirm = async () => {
+    const succeeded = await handleDelete()
+    if (succeeded) closeModal()
+  }
+
+  return (
+    <Box>
+      <Button
+        color="red"
+        variant="outline"
+        leftSection={<IconTrash size={16} />}
+        onClick={open}
+      >
+        全データを削除
+      </Button>
+
+      <Modal
+        opened={opened}
+        onClose={closeModal}
+        title="全データを削除"
+        centered
+      >
+        <Stack>
+          <Text size="sm">
+            すべての食事記録・目標・プリセットを削除します。
+            この操作は取り消せません。アカウントは残るので、引き続きご利用いただけます。
+          </Text>
+
+          {deleteStatus === 'error' && (
+            <Alert
+              color="red"
+              icon={<IconAlertTriangle size={16} />}
+              title="削除に失敗しました"
+            >
+              一部のデータが削除できませんでした。もう一度お試しください。
+            </Alert>
+          )}
+
+          <Checkbox
+            checked={consented}
+            onChange={(event) => setConsented(event.currentTarget.checked)}
+            label="内容を理解した上で、全データを削除します"
+            disabled={isDeleting}
+          />
+
+          <Group justify="flex-end">
+            <Button
+              variant="default"
+              onClick={closeModal}
+              disabled={isDeleting}
+            >
+              キャンセル
+            </Button>
+            <Button
+              color="red"
+              onClick={onConfirm}
+              loading={isDeleting}
+              disabled={!consented}
+            >
+              削除する
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </Box>
+  )
+}

--- a/src/features/account-deletion/components/DeleteAllDataButton.tsx
+++ b/src/features/account-deletion/components/DeleteAllDataButton.tsx
@@ -1,36 +1,11 @@
-import {
-  Alert,
-  Box,
-  Button,
-  Checkbox,
-  Group,
-  Modal,
-  Stack,
-  Text,
-} from '@mantine/core'
+import { Box, Button } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
-import { IconAlertTriangle, IconTrash } from '@tabler/icons-react'
-import { useState } from 'react'
+import { IconTrash } from '@tabler/icons-react'
 
-import { useDeleteAllData } from '../hooks/useDeleteAllData'
+import { DeleteAllDataModal } from './DeleteAllDataModal'
 
 export function DeleteAllDataButton() {
   const [opened, { open, close }] = useDisclosure(false)
-  const [consented, setConsented] = useState(false)
-  const { deleteStatus, handleDelete } = useDeleteAllData()
-
-  const isDeleting = deleteStatus === 'loading'
-
-  const closeModal = () => {
-    if (isDeleting) return
-    close()
-    setConsented(false)
-  }
-
-  const onConfirm = async () => {
-    const succeeded = await handleDelete()
-    if (succeeded) closeModal()
-  }
 
   return (
     <Box>
@@ -43,54 +18,7 @@ export function DeleteAllDataButton() {
         全データを削除
       </Button>
 
-      <Modal
-        opened={opened}
-        onClose={closeModal}
-        title="全データを削除"
-        centered
-      >
-        <Stack>
-          <Text size="sm">
-            すべての食事記録・目標・プリセットを削除します。
-            この操作は取り消せません。アカウントは残るので、引き続きご利用いただけます。
-          </Text>
-
-          {deleteStatus === 'error' && (
-            <Alert
-              color="red"
-              icon={<IconAlertTriangle size={16} />}
-              title="削除に失敗しました"
-            >
-              一部のデータが削除できませんでした。もう一度お試しください。
-            </Alert>
-          )}
-
-          <Checkbox
-            checked={consented}
-            onChange={(event) => setConsented(event.currentTarget.checked)}
-            label="内容を理解した上で、全データを削除します"
-            disabled={isDeleting}
-          />
-
-          <Group justify="flex-end">
-            <Button
-              variant="default"
-              onClick={closeModal}
-              disabled={isDeleting}
-            >
-              キャンセル
-            </Button>
-            <Button
-              color="red"
-              onClick={onConfirm}
-              loading={isDeleting}
-              disabled={!consented}
-            >
-              削除する
-            </Button>
-          </Group>
-        </Stack>
-      </Modal>
+      {opened && <DeleteAllDataModal opened={opened} close={close} />}
     </Box>
   )
 }

--- a/src/features/account-deletion/components/DeleteAllDataModal.tsx
+++ b/src/features/account-deletion/components/DeleteAllDataModal.tsx
@@ -34,14 +34,20 @@ export function DeleteAllDataModal({ opened, close }: DeleteAllDataModalProps) {
   }
 
   return (
-    <Modal opened={opened} onClose={closeModal} title="全データを削除" centered>
-      <Stack>
-        <Text size="sm" c="red">
-          すべての食事記録、目標、プリセットを削除します。
+    <Modal
+      opened={opened}
+      onClose={closeModal}
+      title="全データを削除"
+      centered
+      styles={{ title: { flex: 1, textAlign: 'center' } }}
+    >
+      <Stack align="center">
+        <Text size="sm" c="red" ta="center">
+          すべての食事記録、目標、プリセットを削除します
           <br />
-          アカウントは削除されません。
+          アカウントは削除されません
           <br />
-          この操作は取り消せません。
+          この操作は取り消せません
         </Text>
 
         {deleteStatus === 'error' && (
@@ -57,11 +63,11 @@ export function DeleteAllDataModal({ opened, close }: DeleteAllDataModalProps) {
         <Checkbox
           checked={consented}
           onChange={(event) => setConsented(event.currentTarget.checked)}
-          label="内容を理解した上で、全データを削除します"
+          label="内容を理解しました。全データを削除します"
           disabled={isDeleting}
         />
 
-        <Group justify="flex-end">
+        <Group justify="center">
           <Button variant="default" onClick={closeModal} disabled={isDeleting}>
             キャンセル
           </Button>

--- a/src/features/account-deletion/components/DeleteAllDataModal.tsx
+++ b/src/features/account-deletion/components/DeleteAllDataModal.tsx
@@ -1,0 +1,80 @@
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Group,
+  Modal,
+  Stack,
+  Text,
+} from '@mantine/core'
+import { IconAlertTriangle } from '@tabler/icons-react'
+import { useState } from 'react'
+
+import { useDeleteAllData } from '../hooks/useDeleteAllData'
+
+type DeleteAllDataModalProps = {
+  opened: boolean
+  close: () => void
+}
+
+export function DeleteAllDataModal({ opened, close }: DeleteAllDataModalProps) {
+  const [consented, setConsented] = useState(false)
+  const { deleteStatus, handleDelete } = useDeleteAllData()
+
+  const isDeleting = deleteStatus === 'loading'
+
+  const closeModal = () => {
+    if (isDeleting) return
+    close()
+  }
+
+  const onConfirm = async () => {
+    const succeeded = await handleDelete()
+    if (succeeded) closeModal()
+  }
+
+  return (
+    <Modal opened={opened} onClose={closeModal} title="全データを削除" centered>
+      <Stack>
+        <Text size="sm" c="red">
+          すべての食事記録、目標、プリセットを削除します。
+          <br />
+          アカウントは削除されません。
+          <br />
+          この操作は取り消せません。
+        </Text>
+
+        {deleteStatus === 'error' && (
+          <Alert
+            color="red"
+            icon={<IconAlertTriangle size={16} />}
+            title="削除に失敗しました"
+          >
+            一部のデータが削除できませんでした。もう一度お試しください。
+          </Alert>
+        )}
+
+        <Checkbox
+          checked={consented}
+          onChange={(event) => setConsented(event.currentTarget.checked)}
+          label="内容を理解した上で、全データを削除します"
+          disabled={isDeleting}
+        />
+
+        <Group justify="flex-end">
+          <Button variant="default" onClick={closeModal} disabled={isDeleting}>
+            キャンセル
+          </Button>
+          <Button
+            color="red"
+            onClick={onConfirm}
+            loading={isDeleting}
+            disabled={!consented}
+          >
+            削除する
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  )
+}

--- a/src/features/account-deletion/hooks/useDeleteAllData.ts
+++ b/src/features/account-deletion/hooks/useDeleteAllData.ts
@@ -1,0 +1,41 @@
+import {
+  type SaveStatus,
+  useStatusButtonState,
+} from '@/components/StatusButton'
+import { SAVE_BUTTON_REENABLE_DELAY_MS } from '@/constants'
+
+import { purgeAllUserData } from '../utils/purgeAllUserData'
+import { resetStoresAfterPurge } from '../utils/resetStoresAfterPurge'
+
+type UseDeleteAllData = {
+  deleteStatus: SaveStatus
+  handleDelete: () => Promise<boolean>
+}
+
+/**
+ * Deletes all of the signed-in user's data, then resets the client stores so
+ * the UI reflects the empty state immediately. Loading/success/error feedback
+ * reuses the shared status-button state.
+ */
+export function useDeleteAllData(): UseDeleteAllData {
+  const { saveStatus, startLoading, markSuccess, markError } =
+    useStatusButtonState(SAVE_BUTTON_REENABLE_DELAY_MS)
+
+  const handleDelete = async (): Promise<boolean> => {
+    startLoading()
+    try {
+      await purgeAllUserData()
+      resetStoresAfterPurge()
+      markSuccess()
+      return true
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('Failed to purge user data:', error)
+      }
+      markError()
+      return false
+    }
+  }
+
+  return { deleteStatus: saveStatus, handleDelete }
+}

--- a/src/features/account-deletion/index.ts
+++ b/src/features/account-deletion/index.ts
@@ -1,0 +1,1 @@
+export { purgeAllUserData } from './utils/purgeAllUserData'

--- a/src/features/account-deletion/index.ts
+++ b/src/features/account-deletion/index.ts
@@ -1,1 +1,1 @@
-export { purgeAllUserData } from './utils/purgeAllUserData'
+export { DeleteAllDataButton } from './components/DeleteAllDataButton'

--- a/src/features/account-deletion/utils/purgeAllUserData.ts
+++ b/src/features/account-deletion/utils/purgeAllUserData.ts
@@ -1,0 +1,78 @@
+import { parallel } from 'radash'
+
+import { deleteDailyGoal, fetchAllDailyGoalIds } from '@/api/daily-goal'
+import {
+  deleteDailyMealRecord,
+  fetchAllDailyMealRecordIds,
+} from '@/api/daily-meal-record'
+import { clearAllGuestData } from '@/api/guest/guest-storage'
+import { getGuestModeFlag } from '@/api/guest/guestModeFlag'
+import {
+  deleteUserMealPreset,
+  fetchAllUserMealPresetIds,
+} from '@/api/user-meal-preset'
+
+// Cap concurrent delete mutations so a large purge does not trip AppSync
+// throttling. Failures are collected rather than aborting the batch, so a
+// modest limit keeps pressure low without slowing small accounts noticeably.
+const DELETE_CONCURRENCY = 10
+
+/**
+ * Deletes every piece of the signed-in user's data: all daily meal records,
+ * daily goals and meal presets. The Cognito account itself is left intact.
+ *
+ * In guest mode there is no backend data, so this clears localStorage instead
+ * and returns early. The two modes never mix.
+ *
+ * Idempotent by design.
+ * Records are listed and then deleted, so a run that
+ * fails partway can simply be retried: the next run re-lists only what remains.
+ *
+ * @returns Nothing. Throws an AggregateError if any record fails to delete.
+ */
+export async function purgeAllUserData(): Promise<void> {
+  if (getGuestModeFlag()) {
+    clearAllGuestData()
+    return
+  }
+
+  // Reads are independent, so enumerate every model's ids in parallel.
+  const [mealRecordIds, dailyGoalIds, userMealPresetIds] = await Promise.all([
+    fetchAllDailyMealRecordIds(),
+    fetchAllDailyGoalIds(),
+    fetchAllUserMealPresetIds(),
+  ])
+
+  // Attempt all three groups regardless of individual failures, then surface
+  // any errors together (Promise.allSettled never short-circuits).
+  const results = await Promise.allSettled([
+    parallel(DELETE_CONCURRENCY, mealRecordIds, (id) =>
+      deleteDailyMealRecord({ input: { id } }),
+    ),
+    parallel(DELETE_CONCURRENCY, dailyGoalIds, (id) =>
+      deleteDailyGoal({ input: { id } }),
+    ),
+    parallel(DELETE_CONCURRENCY, userMealPresetIds, (id) =>
+      deleteUserMealPreset({ input: { id } }),
+    ),
+  ])
+
+  // radash `parallel` rejects with an AggregateError bundling every failed
+  // item; flatten those so the caller sees one flat list of underlying errors.
+  const errors = results
+    .filter(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
+    )
+    .flatMap((result) =>
+      result.reason instanceof AggregateError
+        ? result.reason.errors
+        : [result.reason],
+    )
+
+  if (errors.length > 0) {
+    throw new AggregateError(
+      errors,
+      `Failed to delete ${errors.length} record(s) during purge`,
+    )
+  }
+}

--- a/src/features/account-deletion/utils/resetStoresAfterPurge.ts
+++ b/src/features/account-deletion/utils/resetStoresAfterPurge.ts
@@ -1,0 +1,20 @@
+import {
+  useDailyGoalStore,
+  useNutritionNumbersStore,
+  usePresetNutritionNumbersStore,
+  useUserMealPresetStore,
+  useWeeklyDailyMealRecordsStore,
+} from '@/stores'
+
+/**
+ * Resets every store that holds the signed-in user's data back to its initial
+ * state after a successful purge, so no stale numbers or records linger on
+ * screen until the next fetch.
+ */
+export function resetStoresAfterPurge(): void {
+  useDailyGoalStore.getState().reset()
+  useWeeklyDailyMealRecordsStore.getState().reset()
+  useUserMealPresetStore.getState().reset()
+  useNutritionNumbersStore.getState().reset()
+  usePresetNutritionNumbersStore.getState().reset()
+}

--- a/src/features/account-header/AccountHeader.tsx
+++ b/src/features/account-header/AccountHeader.tsx
@@ -1,0 +1,9 @@
+import { Title } from '@mantine/core'
+
+export function AccountHeader() {
+  return (
+    <Title order={4} fw={400} c="dimmed" mb="xs">
+      アカウントを管理します
+    </Title>
+  )
+}

--- a/src/features/account-header/index.ts
+++ b/src/features/account-header/index.ts
@@ -1,0 +1,1 @@
+export { AccountHeader } from './AccountHeader'

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -2,6 +2,8 @@ import { Box } from '@mantine/core'
 
 import { Layout } from '../components/Layout'
 import { Robots } from '../constants'
+import { DeleteAllDataButton } from '../features/account-deletion'
+import { AccountHeader } from '../features/account-header'
 import { DailyGoal } from '../features/daily-goal'
 import { DailyGoalHeader } from '../features/daily-goal-header'
 
@@ -12,8 +14,16 @@ export default function Settings() {
         <DailyGoalHeader />
       </Box>
 
-      <Box maw={400} mb={30}>
+      <Box maw={400} mb={50}>
         <DailyGoal />
+      </Box>
+
+      <Box maw={300} mb={30}>
+        <AccountHeader />
+      </Box>
+
+      <Box maw={400} mb={30}>
+        <DeleteAllDataButton />
       </Box>
     </Layout>
   )

--- a/src/stores/dailyGoal.ts
+++ b/src/stores/dailyGoal.ts
@@ -16,9 +16,11 @@ const initialDailyGoal: DailyGoal = {
 export type DailyGoalState = {
   dailyGoal: DailyGoal
   setDailyGoal: (dailyGoal: DailyGoal) => void
+  reset: () => void
 }
 
 export const useDailyGoalStore = create<DailyGoalState>()((set) => ({
   dailyGoal: { ...initialDailyGoal },
   setDailyGoal: (newDailyGoal) => set({ dailyGoal: newDailyGoal }),
+  reset: () => set({ dailyGoal: { ...initialDailyGoal } }),
 }))

--- a/src/stores/nutritionNumbers.ts
+++ b/src/stores/nutritionNumbers.ts
@@ -9,6 +9,7 @@ export type NutritionNumbersState = {
   setDailyProtein: (dailyProtein: number) => void
   setDailyFat: (dailyFat: number) => void
   setDailyCarbohydrates: (dailyCarbohydrates: number) => void
+  reset: () => void
 }
 
 export const useNutritionNumbersStore = create<NutritionNumbersState>()(
@@ -24,5 +25,12 @@ export const useNutritionNumbersStore = create<NutritionNumbersState>()(
     setDailyFat: (newDailyFat) => set({ dailyFat: newDailyFat }),
     setDailyCarbohydrates: (newDailyCarbohydrates) =>
       set({ dailyCarbohydrates: newDailyCarbohydrates }),
+    reset: () =>
+      set({
+        dailyCalories: 0,
+        dailyProtein: 0,
+        dailyFat: 0,
+        dailyCarbohydrates: 0,
+      }),
   }),
 )

--- a/src/stores/presetNutritionNumbers.ts
+++ b/src/stores/presetNutritionNumbers.ts
@@ -9,6 +9,7 @@ export type PresetNutritionNumbersState = {
   setPresetProtein: (presetProtein: number) => void
   setPresetFat: (presetFat: number) => void
   setPresetCarbohydrates: (presetCarbohydrates: number) => void
+  reset: () => void
 }
 
 export const usePresetNutritionNumbersStore =
@@ -24,4 +25,11 @@ export const usePresetNutritionNumbersStore =
     setPresetFat: (newPresetFat) => set({ presetFat: newPresetFat }),
     setPresetCarbohydrates: (newPresetCarbohydrates) =>
       set({ presetCarbohydrates: newPresetCarbohydrates }),
+    reset: () =>
+      set({
+        presetCalories: 0,
+        presetProtein: 0,
+        presetFat: 0,
+        presetCarbohydrates: 0,
+      }),
   }))

--- a/src/stores/userMealPresetStore.ts
+++ b/src/stores/userMealPresetStore.ts
@@ -5,9 +5,11 @@ import { UserMealPreset } from '../API'
 export type UserMealPresetState = {
   userMealPreset: UserMealPreset | null
   setUserMealPreset: (userMealPreset: UserMealPreset | null) => void
+  reset: () => void
 }
 
 export const useUserMealPresetStore = create<UserMealPresetState>((set) => ({
   userMealPreset: null,
   setUserMealPreset: (userMealPreset) => set({ userMealPreset }),
+  reset: () => set({ userMealPreset: null }),
 }))

--- a/src/stores/weeklyDailyMealRecords.ts
+++ b/src/stores/weeklyDailyMealRecords.ts
@@ -5,6 +5,7 @@ import { DailyMealRecord } from '../API'
 export type WeeklyDailyMealRecordsState = {
   weeklyDailyMealRecords: DailyMealRecord[]
   setWeeklyDailyMealRecords: (weeklyDailyMealRecords: DailyMealRecord[]) => void
+  reset: () => void
 }
 
 export const useWeeklyDailyMealRecordsStore =
@@ -12,4 +13,5 @@ export const useWeeklyDailyMealRecordsStore =
     weeklyDailyMealRecords: [],
     setWeeklyDailyMealRecords: (newWeeklyDailyMealRecords) =>
       set({ weeklyDailyMealRecords: newWeeklyDailyMealRecords }),
+    reset: () => set({ weeklyDailyMealRecords: [] }),
   }))


### PR DESCRIPTION
## Summary

Settings-page flow that lets a signed-in user delete all of their own data while keeping their Cognito account.

## Changes

- **API layer** — add `delete` wrappers for `DailyGoal`, `DailyMealRecord` and `UserMealPreset`
- **API layer** — add `fetch-all-*-ids` helpers that paginate the list query until `nextToken` is null (owner filter can return empty pages, so termination keys on `nextToken`, not empty items)
- **Orchestrator** — add `purgeAllUserData`: guest mode clears `localStorage`; owner mode lists every id then deletes via radash `parallel` with capped concurrency
  - idempotent: list → delete order means a partially failed run can be retried
  - `Promise.allSettled` across models + flattened `AggregateError` so one failure doesn't leave other models untouched
- **UI** — add `DeleteAllDataButton` (trigger) and `DeleteAllDataModal` (confirmation with checkbox consent, irreversibility notice, error/retry), mirroring the existing `LogoutModal` pattern
- **Hook** — add `useDeleteAllData`: runs the purge, resets stores on full success only, reuses the shared status-button state for loading/success/error
- **Stores** — add a `reset` action to the five stores holding user data
- **Settings** — add an account section (`AccountHeader` + delete button) at the bottom of the page
