### PR TITLE
feat: add account withdrawal flow

### DIFF
--- a/src/features/account-deletion/components/WithdrawButton.tsx
+++ b/src/features/account-deletion/components/WithdrawButton.tsx
@@ -1,0 +1,29 @@
+import { Box, Button } from '@mantine/core'
+import { useDisclosure } from '@mantine/hooks'
+import { IconUserX } from '@tabler/icons-react'
+
+import { useGuestModeStore } from '@/stores'
+
+import { WithdrawModal } from './WithdrawModal'
+
+export function WithdrawButton() {
+  const isGuestMode = useGuestModeStore((state) => state.isGuestMode)
+  const [opened, { open, close }] = useDisclosure(false)
+
+  if (isGuestMode) return null
+
+  return (
+    <Box>
+      <Button
+        color="red"
+        variant="filled"
+        leftSection={<IconUserX size={16} />}
+        onClick={open}
+      >
+        退会する
+      </Button>
+
+      {opened && <WithdrawModal opened={opened} close={close} />}
+    </Box>
+  )
+}

--- a/src/features/account-deletion/components/WithdrawModal.tsx
+++ b/src/features/account-deletion/components/WithdrawModal.tsx
@@ -1,0 +1,91 @@
+import {
+  Alert,
+  Button,
+  Group,
+  Modal,
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core'
+import { IconAlertTriangle } from '@tabler/icons-react'
+import { useState } from 'react'
+
+import { useWithdrawAccount } from '../hooks/useWithdrawAccount'
+
+const CONFIRM_WORD = '退会'
+
+type WithdrawModalProps = {
+  opened: boolean
+  close: () => void
+}
+
+export function WithdrawModal({ opened, close }: WithdrawModalProps) {
+  const [confirmText, setConfirmText] = useState('')
+  const { withdrawStatus, errorMessage, handleWithdraw } = useWithdrawAccount()
+
+  const isWithdrawing = withdrawStatus === 'loading'
+  const canWithdraw = confirmText.trim() === CONFIRM_WORD && !isWithdrawing
+
+  const closeModal = () => {
+    if (isWithdrawing) return
+    close()
+  }
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={closeModal}
+      title="退会する"
+      centered
+      styles={{ title: { flex: 1, textAlign: 'center' } }}
+    >
+      <Stack align="center">
+        <Text size="sm" c="red" ta="center">
+          アカウントと、すべての食事記録・目標・プリセットが完全に削除されます
+          <br />
+          削除したデータとアカウントは復元できません
+          <br />
+          この操作は取り消せません
+        </Text>
+
+        {withdrawStatus === 'error' && errorMessage && (
+          <Alert
+            w="100%"
+            color="red"
+            icon={<IconAlertTriangle size={16} />}
+            title="退会に失敗しました"
+          >
+            {errorMessage}
+          </Alert>
+        )}
+
+        <TextInput
+          w="100%"
+          label={`確認のため「${CONFIRM_WORD}」と入力してください`}
+          placeholder={CONFIRM_WORD}
+          value={confirmText}
+          onChange={(event) => setConfirmText(event.currentTarget.value)}
+          disabled={isWithdrawing}
+        />
+
+        <Group justify="center">
+          <Button
+            variant="default"
+            onClick={closeModal}
+            disabled={isWithdrawing}
+          >
+            キャンセル
+          </Button>
+          <Button
+            color="red"
+            onClick={handleWithdraw}
+            loading={isWithdrawing}
+            disabled={!canWithdraw}
+          >
+            退会する
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  )
+}

--- a/src/features/account-deletion/hooks/useWithdrawAccount.ts
+++ b/src/features/account-deletion/hooks/useWithdrawAccount.ts
@@ -1,0 +1,70 @@
+import { useAuthenticator } from '@aws-amplify/ui-react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+
+import {
+  type SaveStatus,
+  useStatusButtonState,
+} from '@/components/StatusButton'
+import { Path, SAVE_BUTTON_REENABLE_DELAY_MS } from '@/constants'
+
+import { withdrawAccount } from '../utils/withdrawAccount'
+
+type UseWithdrawAccount = {
+  withdrawStatus: SaveStatus
+  errorMessage: string | null
+  handleWithdraw: () => Promise<void>
+}
+
+const REAUTH_ERROR_NAMES = ['NotAuthorizedException', 'NotAuthorizedError']
+const REAUTH_ERROR_MESSAGE =
+  '認証の有効期限が切れている可能性があります。お手数ですが、もう一度ログインしてからお試しください。'
+const DEFAULT_ERROR_MESSAGE =
+  '退会処理に失敗しました。データの削除は完了している場合があります。時間をおいて、もう一度お試しください。'
+
+function resolveErrorMessage(error: unknown): string {
+  const name = error instanceof Error ? error.name : ''
+  return REAUTH_ERROR_NAMES.includes(name)
+    ? REAUTH_ERROR_MESSAGE
+    : DEFAULT_ERROR_MESSAGE
+}
+
+/**
+ * Runs the withdrawal flow (purge → deleteUser), then signs out and redirects
+ * to the landing page.
+ */
+export function useWithdrawAccount(): UseWithdrawAccount {
+  const { signOut } = useAuthenticator()
+  const router = useRouter()
+  const { saveStatus, startLoading, markError } = useStatusButtonState(
+    SAVE_BUTTON_REENABLE_DELAY_MS,
+  )
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const handleWithdraw = async (): Promise<void> => {
+    startLoading()
+    setErrorMessage(null)
+
+    try {
+      await withdrawAccount()
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.error('Failed to withdraw account:', error)
+      }
+      setErrorMessage(resolveErrorMessage(error))
+      markError()
+      return
+    }
+
+    try {
+      await signOut()
+    } catch (error) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('Sign-out after withdrawal failed (ignored):', error)
+      }
+    }
+    router.replace(Path.Landingpage)
+  }
+
+  return { withdrawStatus: saveStatus, errorMessage, handleWithdraw }
+}

--- a/src/features/account-deletion/index.ts
+++ b/src/features/account-deletion/index.ts
@@ -1,1 +1,2 @@
 export { DeleteAllDataButton } from './components/DeleteAllDataButton'
+export { WithdrawButton } from './components/WithdrawButton'

--- a/src/features/account-deletion/utils/withdrawAccount.ts
+++ b/src/features/account-deletion/utils/withdrawAccount.ts
@@ -1,0 +1,22 @@
+import { deleteUser } from 'aws-amplify/auth'
+
+import { purgeAllUserData } from './purgeAllUserData'
+
+/**
+ * Withdraws (deletes) the signed-in account.
+ *
+ * The order is critical:
+ *   1. Purge all backend data while owner auth is still valid.
+ *   2. Delete the Cognito user itself.
+ *
+ * `deleteUser()` does NOT cascade-delete DynamoDB records, and once the user is
+ * gone the owner-scoped GraphQL API can no longer be called — so deleting the
+ * user first would strand orphaned data. Purge must come first, always.
+ */
+export async function withdrawAccount(): Promise<void> {
+  // 1. delete data first (needs owner auth)
+  await purgeAllUserData()
+
+  // 2. delete the account last
+  await deleteUser()
+}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -2,7 +2,10 @@ import { Box } from '@mantine/core'
 
 import { Layout } from '../components/Layout'
 import { Robots } from '../constants'
-import { DeleteAllDataButton } from '../features/account-deletion'
+import {
+  DeleteAllDataButton,
+  WithdrawButton,
+} from '../features/account-deletion'
 import { AccountHeader } from '../features/account-header'
 import { DailyGoal } from '../features/daily-goal'
 import { DailyGoalHeader } from '../features/daily-goal-header'
@@ -24,6 +27,10 @@ export default function Settings() {
 
       <Box maw={400} mb={30}>
         <DeleteAllDataButton />
+      </Box>
+
+      <Box maw={400} mb={30}>
+        <WithdrawButton />
       </Box>
     </Layout>
   )


### PR DESCRIPTION
Add self-service account withdrawal on the settings page. The flow purges all user data first (while owner auth is still valid), then deletes the Cognito user, signs out, and redirects to the landing page.

- withdrawAccount orchestrator fixes the purge -> deleteUser order so a failed purge never strands orphaned DynamoDB data
- useWithdrawAccount separates withdrawal failure from post-delete sign-out failure and surfaces a re-auth-specific message for NotAuthorizedException
- WithdrawModal requires typing the confirmation word before enabling
- WithdrawButton is hidden in guest mode (no Cognito account exists)