### PR TITLE
refactor: split /settings into /daily-goal and /settings

### DIFF
--- a/src/components/LayoutNavBar/utils.ts
+++ b/src/components/LayoutNavBar/utils.ts
@@ -3,6 +3,7 @@ import {
   IconAlbum,
   IconBoxMultiple7,
   IconClockHour9,
+  IconSettings,
 } from '@tabler/icons-react'
 
 import { Path } from '../../constants'
@@ -11,5 +12,6 @@ export const createLinkItems = () => [
   { path: Path.Day, label: '日別', icon: IconClockHour9 },
   { path: Path.Week, label: '週間', icon: IconBoxMultiple7 },
   { path: Path.Preset, label: 'プリセット', icon: IconAlbum },
-  { path: Path.Settings, label: '目標設定', icon: IconAdjustmentsHorizontal },
+  { path: Path.DailyGoal, label: '目標設定', icon: IconAdjustmentsHorizontal },
+  { path: Path.Settings, label: '設定', icon: IconSettings },
 ]

--- a/src/components/LayoutNavBar/utils.ts
+++ b/src/components/LayoutNavBar/utils.ts
@@ -12,6 +12,6 @@ export const createLinkItems = () => [
   { path: Path.Day, label: '日別', icon: IconClockHour9 },
   { path: Path.Week, label: '週間', icon: IconBoxMultiple7 },
   { path: Path.Preset, label: 'プリセット', icon: IconAlbum },
-  { path: Path.DailyGoal, label: '目標設定', icon: IconAdjustmentsHorizontal },
+  { path: Path.DailyGoal, label: '目標', icon: IconAdjustmentsHorizontal },
   { path: Path.Settings, label: '設定', icon: IconSettings },
 ]

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -3,6 +3,7 @@ export enum Path {
   Day = '/day',
   Week = '/week',
   Preset = '/preset',
+  DailyGoal = '/daily-goal',
   Settings = '/settings',
   Landingpage = '/landingpage',
   Terms = '/terms',

--- a/src/pages/daily-goal.tsx
+++ b/src/pages/daily-goal.tsx
@@ -1,0 +1,20 @@
+import { Box } from '@mantine/core'
+
+import { Layout } from '../components/Layout'
+import { Robots } from '../constants'
+import { DailyGoal } from '../features/daily-goal'
+import { DailyGoalHeader } from '../features/daily-goal-header'
+
+export default function DailyGoalPage() {
+  return (
+    <Layout title="目標設定" robots={Robots.NoindexNofollow}>
+      <Box maw={300} mb={30}>
+        <DailyGoalHeader />
+      </Box>
+
+      <Box maw={400} mb={30}>
+        <DailyGoal />
+      </Box>
+    </Layout>
+  )
+}

--- a/src/pages/daily-goal.tsx
+++ b/src/pages/daily-goal.tsx
@@ -7,7 +7,7 @@ import { DailyGoalHeader } from '../features/daily-goal-header'
 
 export default function DailyGoalPage() {
   return (
-    <Layout title="目標設定" robots={Robots.NoindexNofollow}>
+    <Layout title="目標" robots={Robots.NoindexNofollow}>
       <Box maw={300} mb={30}>
         <DailyGoalHeader />
       </Box>

--- a/src/pages/day.tsx
+++ b/src/pages/day.tsx
@@ -6,7 +6,7 @@ import { DailyMealForm } from '../features/daily-meal-form'
 import { DailyNutritions } from '../features/daily-nutritions'
 import { DatePickerCard } from '../features/date-picker-card'
 
-export default function Day() {
+export default function DayPage() {
   return (
     <Layout title="日別" robots={Robots.NoindexNofollow}>
       <Box maw={300} mb={30}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps } from 'next'
 
 import { Path } from '../constants'
 
-export default function Home() {
+export default function HomePage() {
   return <></>
 }
 

--- a/src/pages/landingpage.tsx
+++ b/src/pages/landingpage.tsx
@@ -11,7 +11,7 @@ const LP_DESCRIPTION =
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'
 const OGP_IMAGE_URL = `${SITE_URL}/images/ogp/day-desktop.png`
 
-export default function Lp() {
+export default function LpPage() {
   return (
     <Layout
       title={LP_TITLE}

--- a/src/pages/preset.tsx
+++ b/src/pages/preset.tsx
@@ -6,7 +6,7 @@ import { PresetHeader } from '../features/preset-header'
 import { PresetMealForm } from '../features/preset-meal-form'
 import { PresetNutritions } from '../features/preset-nutritions'
 
-export default function Preset() {
+export default function PresetPage() {
   return (
     <Layout title="プリセット" robots={Robots.NoindexNofollow}>
       <Box maw={300} mb={30}>

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -26,7 +26,7 @@ const sections = [
   },
 ]
 
-export default function PrivacyPolicy() {
+export default function PrivacyPolicyPage() {
   return (
     <Layout title="プライバシーポリシー" robots={Robots.NoindexFollow}>
       <LegalDocumentMock

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -7,20 +7,10 @@ import {
   WithdrawButton,
 } from '../features/account-deletion'
 import { AccountHeader } from '../features/account-header'
-import { DailyGoal } from '../features/daily-goal'
-import { DailyGoalHeader } from '../features/daily-goal-header'
 
-export default function Settings() {
+export default function SettingsPage() {
   return (
-    <Layout title="目標設定" robots={Robots.NoindexNofollow}>
-      <Box maw={300} mb={30}>
-        <DailyGoalHeader />
-      </Box>
-
-      <Box maw={400} mb={50}>
-        <DailyGoal />
-      </Box>
-
+    <Layout title="設定" robots={Robots.NoindexNofollow}>
       <Box maw={300} mb={30}>
         <AccountHeader />
       </Box>

--- a/src/pages/week.tsx
+++ b/src/pages/week.tsx
@@ -6,7 +6,7 @@ import { DatePickerCard } from '../features/date-picker-card'
 import { WeeklyCaloriesChart } from '../features/weekly-calories-chart'
 import { WeeklyNutritions } from '../features/weekly-nutritions'
 
-export default function Week() {
+export default function WeekPage() {
   return (
     <Layout title="週間" robots={Robots.NoindexNofollow}>
       <Box maw={300} mb={30}>


### PR DESCRIPTION
Separate the goal-setting screen from app settings ahead of the freemium Phase 2 subscription UI:

- Add /daily-goal route (singular, matching existing routes and the DailyGoal model) hosting DailyGoalHeader + DailyGoal
- Keep /settings for account management (data deletion, withdrawal) and add a settings nav entry so the account flows stay reachable
- Point the goal-setting nav entry at /daily-goal
- Standardize page component names with a Page suffix