### PR TITLE
fix: keep current page on reload instead of redirecting to /day

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -47,7 +47,9 @@ function MyApp({ Component, pageProps }: AppProps) {
 
     if (authStatus === 'authenticated') {
       fetchAndSetDailyGoal(setDailyGoal)
-      router.push(Path.Day)
+      if (router.pathname === Path.Landingpage) {
+        router.push(Path.Day)
+      }
       return
     }
 


### PR DESCRIPTION
Redirect authenticated users to /day only from the landing page, matching the guest-mode behavior, so reloading /week, /preset, etc. no longer forces navigation back to /day.