### PR TITLE
fix: paginate list queries so filtered records are not missed

### DIFF
--- a/src/api/daily-meal-record/fetch-daily-meal-records.ts
+++ b/src/api/daily-meal-record/fetch-daily-meal-records.ts
@@ -23,20 +23,33 @@ export const fetchDailyMealRecords = async (
   if (getGuestModeFlag()) return guestFetchDailyMealRecords(variables)
 
   try {
-    const { data } = await client.graphql<
-      GraphQLQuery<ListDailyMealRecordsQuery>
-    >({
-      query: listDailyMealRecords,
-      variables,
-      authMode: 'userPool',
-    })
+    const validDailyMealRecordIds: string[] = []
+    let nextToken: string | null | undefined = undefined
 
-    const dailyMealRecords = data?.listDailyMealRecords?.items || []
+    do {
+      const pageVariables: ListDailyMealRecordsQueryVariables = {
+        ...variables,
+        nextToken,
+      }
 
-    // Filter out null records and map to their IDs
-    const validDailyMealRecordIds = dailyMealRecords
-      .filter((record) => record !== null)
-      .map((record) => record!.id)
+      const { data } = await client.graphql<
+        GraphQLQuery<ListDailyMealRecordsQuery>
+      >({
+        query: listDailyMealRecords,
+        variables: pageVariables,
+        authMode: 'userPool',
+      })
+
+      const result = data?.listDailyMealRecords
+
+      // Filter out null records and map to their IDs
+      const pageIds = (result?.items ?? [])
+        .filter((record) => record !== null)
+        .map((record) => record!.id)
+
+      validDailyMealRecordIds.push(...pageIds)
+      nextToken = result?.nextToken
+    } while (nextToken)
 
     // If no valid daily meal record IDs, return an empty array
     if (validDailyMealRecordIds.length === 0) {

--- a/src/api/daily-meal-record/fetch-weekly-daily-meal-records.ts
+++ b/src/api/daily-meal-record/fetch-weekly-daily-meal-records.ts
@@ -27,27 +27,38 @@ export const fetchWeeklyDailyMealRecords = async (
       currentDateString,
       prevWeekDateString,
     )
-  const variables: ListDailyMealRecordsQueryVariables = {
-    filter: {
-      date: { between: [prevWeekDateString, currentDateString] },
-    },
+  const filter = {
+    date: { between: [prevWeekDateString, currentDateString] },
   }
 
   try {
-    const { data } = await client.graphql<
-      GraphQLQuery<ListDailyMealRecordsQuery>
-    >({
-      query: listDailyMealRecords,
-      variables,
-      authMode: 'userPool',
-    })
+    const validDailyMealRecordIds: string[] = []
+    let nextToken: string | null | undefined = undefined
 
-    const dailyMealRecords = data?.listDailyMealRecords?.items || []
+    do {
+      const variables: ListDailyMealRecordsQueryVariables = {
+        filter,
+        nextToken,
+      }
 
-    // Remove null entries and fetch detailed records
-    const validDailyMealRecordIds = dailyMealRecords
-      .filter((record) => record !== null)
-      .map((record) => record!.id)
+      const { data } = await client.graphql<
+        GraphQLQuery<ListDailyMealRecordsQuery>
+      >({
+        query: listDailyMealRecords,
+        variables,
+        authMode: 'userPool',
+      })
+
+      const result = data?.listDailyMealRecords
+
+      // Remove null entries and keep their IDs
+      const pageIds = (result?.items ?? [])
+        .filter((record) => record !== null)
+        .map((record) => record!.id)
+
+      validDailyMealRecordIds.push(...pageIds)
+      nextToken = result?.nextToken
+    } while (nextToken)
 
     const dailyMealRecordsWithFoods = await Promise.all(
       validDailyMealRecordIds.map((id) => fetchDailyMealRecordWithFoods(id)),

--- a/src/api/user-meal-preset/fetch-user-meal-preset.ts
+++ b/src/api/user-meal-preset/fetch-user-meal-preset.ts
@@ -12,6 +12,41 @@ import { getGuestModeFlag } from '../guest/guestModeFlag'
 import { fetchUserMealPresetWithFood } from './fetch-user-meal-preset-with-food'
 
 /**
+ * Finds the first user meal preset across every page of the list query.
+ * The list query is a filtered Scan, so the preset can sit on a later page.
+ *
+ * @param variables - Optional query variables to filter the presets.
+ * @returns The first preset found, or undefined when there is none.
+ */
+const findUserMealPreset = async (
+  variables?: ListUserMealPresetsQueryVariables,
+): Promise<UserMealPreset | undefined> => {
+  let userMealPreset: UserMealPreset | undefined = undefined
+  let nextToken: string | null | undefined = undefined
+
+  do {
+    const pageVariables: ListUserMealPresetsQueryVariables = {
+      ...variables,
+      nextToken,
+    }
+
+    const { data } = await client.graphql<
+      GraphQLQuery<ListUserMealPresetsQuery>
+    >({
+      query: listUserMealPresets,
+      variables: pageVariables,
+      authMode: 'userPool',
+    })
+
+    const result = data?.listUserMealPresets
+    userMealPreset = (result?.items ?? [])[0] as UserMealPreset | undefined
+    nextToken = result?.nextToken
+  } while (!userMealPreset && nextToken)
+
+  return userMealPreset
+}
+
+/**
  * Fetches the user meal preset data.
  * Since each user should have only one preset, we fetch the first one from the list.
  *
@@ -24,16 +59,8 @@ export const fetchUserMealPreset = async (
   if (getGuestModeFlag()) return guestFetchUserMealPreset()
 
   try {
-    const { data } = await client.graphql<
-      GraphQLQuery<ListUserMealPresetsQuery>
-    >({
-      query: listUserMealPresets,
-      variables,
-      authMode: 'userPool',
-    })
+    const userMealPreset = await findUserMealPreset(variables)
 
-    const userMealPresets = data?.listUserMealPresets?.items || []
-    const userMealPreset = userMealPresets[0] as UserMealPreset
     if (!userMealPreset) {
       console.info('No user meal preset found')
       return null


### PR DESCRIPTION
The owner-scoped list queries run as a DynamoDB Scan: AppSync examines 100 items per page and applies the date filter afterwards. Once a table grows past that, a matching record can sit on a later page, so the first page returns no items plus a nextToken, which callers read as "no data".

Walk every page before deciding a record is missing:
- fetch-daily-meal-records / fetch-weekly-daily-meal-records carry the date filter into each page and collect ids across all of them
- fetch-user-meal-preset stops as soon as a preset turns up; its paging moved into a findUserMealPreset helper to stay under the complexity limit

This mirrors the fix already applied to fetch-daily-goal. The planned GSI migration will replace the Scan with a Query and make the loops unnecessary for the meal records.