### PR TITLE
fix: guard daily meal form against failed record loads

### DIFF
--- a/src/features/daily-meal-form/components/DailyMealForm.tsx
+++ b/src/features/daily-meal-form/components/DailyMealForm.tsx
@@ -22,6 +22,7 @@ import {
 } from '../utils'
 import { DailyMealFormAccordionItem } from './DailyMealFormAccordionItem'
 import { DailyMealFormApplyPresetToAllCategoriesButton } from './DailyMealFormApplyPresetToAllCategoriesButton'
+import { DailyMealFormLoadError } from './DailyMealFormLoadError'
 
 export function DailyMealForm() {
   const currentDate = useCurrentDateStore((state) => state.currentDate)
@@ -31,9 +32,7 @@ export function DailyMealForm() {
   const dailyMealRecord = useDailyMealRecordStore(
     (state) => state.dailyMealRecord,
   )
-  const setDailyMealRecord = useDailyMealRecordStore(
-    (state) => state.setDailyMealRecord,
-  )
+  const loadStatus = useDailyMealRecordStore((state) => state.loadStatus)
   const setUserMealPreset = useUserMealPresetStore(
     (state) => state.setUserMealPreset,
   )
@@ -69,20 +68,17 @@ export function DailyMealForm() {
       setIsDataLoading(true)
       try {
         await Promise.all([
-          loadDailyMealRecord(currentDateString, setDailyMealRecord),
+          loadDailyMealRecord(currentDateString),
           loadUserMealPresetForDay(setUserMealPreset),
         ])
+      } catch {
+        // Keeping the previously loaded preset is the existing behavior.
       } finally {
         setIsDataLoading(false)
       }
     }
     loadAll()
-  }, [
-    currentDateString,
-    setDailyMealRecord,
-    setUserMealPreset,
-    setIsDataLoading,
-  ])
+  }, [currentDateString, setUserMealPreset, setIsDataLoading])
 
   useEffect(() => {
     setDailyCalories(roundToTwoDecimalPlaces(sumCalories))
@@ -91,6 +87,10 @@ export function DailyMealForm() {
     setDailyCarbohydrates(roundToTwoDecimalPlaces(sumCarbohydrates))
     // eslint-disable-next-line
   }, [sumCalories, sumProtein, sumFat, sumCarbohydrates])
+
+  if (loadStatus === 'error') {
+    return <DailyMealFormLoadError />
+  }
 
   return (
     <Box>

--- a/src/features/daily-meal-form/components/DailyMealFormLoadError.tsx
+++ b/src/features/daily-meal-form/components/DailyMealFormLoadError.tsx
@@ -1,0 +1,41 @@
+import { Alert, Button, Stack } from '@mantine/core'
+import { IconAlertTriangle, IconRefresh } from '@tabler/icons-react'
+import { useState } from 'react'
+
+import { useCurrentDateStore } from '../../../stores'
+import { createStringFromDate } from '../../../utils'
+import { loadDailyMealRecord } from '../utils'
+
+export function DailyMealFormLoadError() {
+  const [isRetrying, setIsRetrying] = useState(false)
+  const currentDate = useCurrentDateStore((state) => state.currentDate)
+  const currentDateString = createStringFromDate(currentDate)
+
+  const handleRetry = async () => {
+    setIsRetrying(true)
+    try {
+      await loadDailyMealRecord(currentDateString)
+    } finally {
+      setIsRetrying(false)
+    }
+  }
+
+  return (
+    <Alert
+      color="red"
+      icon={<IconAlertTriangle size={16} />}
+      title="食事記録を読み込めませんでした"
+    >
+      <Stack align="flex-start">
+        <Button
+          variant="default"
+          leftSection={<IconRefresh size={16} />}
+          onClick={handleRetry}
+          loading={isRetrying}
+        >
+          再読み込み
+        </Button>
+      </Stack>
+    </Alert>
+  )
+}

--- a/src/features/daily-meal-form/stores/dailyMealRecord.ts
+++ b/src/features/daily-meal-form/stores/dailyMealRecord.ts
@@ -2,13 +2,19 @@ import { create } from 'zustand'
 
 import { DailyMealRecord } from '../../../API'
 
+export type DailyMealRecordLoadStatus = 'idle' | 'loading' | 'ready' | 'error'
+
 export type DailyMealRecordState = {
   dailyMealRecord: DailyMealRecord | null
+  loadStatus: DailyMealRecordLoadStatus
   setDailyMealRecord: (dailyMealRecord: DailyMealRecord | null) => void
+  setLoadStatus: (loadStatus: DailyMealRecordLoadStatus) => void
 }
 
 export const useDailyMealRecordStore = create<DailyMealRecordState>((set) => ({
   dailyMealRecord: null,
+  loadStatus: 'idle',
   setDailyMealRecord: (newDailyMealRecord) =>
     set({ dailyMealRecord: newDailyMealRecord }),
+  setLoadStatus: (loadStatus) => set({ loadStatus }),
 }))

--- a/src/features/daily-meal-form/utils.ts
+++ b/src/features/daily-meal-form/utils.ts
@@ -20,7 +20,10 @@ import {
 } from '../../api/daily-meal-record'
 import { fetchUserMealPreset } from '../../api/user-meal-preset'
 import { UserMealPresetState } from '../../stores'
-import { DailyMealRecordState } from './stores/dailyMealRecord'
+import {
+  DailyMealRecordState,
+  useDailyMealRecordStore,
+} from './stores/dailyMealRecord'
 import { FormData, FormField, FormsType } from './types'
 
 export { createFoodInitialValues } from '../../utils/createFoodInitialValues'
@@ -115,23 +118,35 @@ export const createDailyMealRecordInitialValues = (
  * Asynchronously loads daily meal record for a specific date
  * and updates the global dailyMealRecord store state.
  *
+ * The record is cleared before fetching so that a failure can never leave the
+ * previous date's record in the store.
+ *
+ * The status is what lets the UI tell "not fetched yet" apart from "no record
+ * for this date", so it is always moved out of 'loading' — including on failure.
+ *
  * @param currentDateString - The date string to filter daily meal records by.
- * @param setDailyMealRecord - Function to update the daily meal record in state.
  * @returns A Promise that resolves when the daily meal record has been loaded and state updated.
  */
-export const loadDailyMealRecord = async (
-  currentDateString: string,
-  setDailyMealRecord: (dailyMealRecord: DailyMealRecord | null) => void,
-) => {
+export const loadDailyMealRecord = async (currentDateString: string) => {
+  const { setDailyMealRecord, setLoadStatus } =
+    useDailyMealRecordStore.getState()
+
+  setLoadStatus('loading')
+  setDailyMealRecord(null)
+
   const variables: ListDailyMealRecordsQueryVariables = {
     filter: {
       date: { eq: currentDateString },
     },
   }
-  // This assumes that there is only one record per date.
-  const dailyMealRecords = await fetchDailyMealRecords(variables)
-  const dailyMealRecord = dailyMealRecords[0] || null
-  setDailyMealRecord(dailyMealRecord)
+
+  try {
+    const dailyMealRecords = await fetchDailyMealRecords(variables)
+    setDailyMealRecord(dailyMealRecords[0] || null)
+    setLoadStatus('ready')
+  } catch {
+    setLoadStatus('error')
+  }
 }
 
 /**
@@ -151,6 +166,8 @@ export const loadUserMealPresetForDay = async (
 /**
  * Saves and sets a DailyMealRecord based on the provided forms and current date string.
  *
+ * Saving is refused unless the record was actually loaded.
+ *
  * @param forms - The forms containing the meal data to be saved.
  * @param currentDateString - The current date as a string.
  * @param dailyMealRecord - The existing daily meal record (if any).
@@ -163,10 +180,18 @@ export const saveAndSetDailyMealRecord = async (
   dailyMealRecord: DailyMealRecord | null,
   setDailyMealRecord: DailyMealRecordState['setDailyMealRecord'],
 ) => {
+  if (useDailyMealRecordStore.getState().loadStatus !== 'ready') {
+    throw new Error('Cannot save a daily meal record that has not been loaded')
+  }
+
   const currentValues = forms.getValues()
   const normalizedFoods = normalizeDailyMealRecordFoods(currentValues)
 
   if (dailyMealRecord) {
+    if (dailyMealRecord.date !== currentDateString) {
+      throw new Error('Cannot save a daily meal record loaded for another date')
+    }
+
     const updateDailyMealRecordInput: UpdateDailyMealRecordInput = {
       id: dailyMealRecord.id,
       date: dailyMealRecord.date,


### PR DESCRIPTION
A failed fetch left the previous date's record in the store, so the form showed it under the new date and saving overwrote that other day. A failed initial fetch left the store null, which read as "no record yet" and created a duplicate for a date that already had one.

Track the fetch with a loadStatus, clear the record before fetching, and refuse to save unless the record was loaded and belongs to the date on screen. Show a reload prompt instead of the form on error.