### PR TITLE
feat: enable AppSync error logging

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -80,6 +80,14 @@ export const data = defineData({
     defaultAuthorizationMode: 'userPool',
   },
   schema,
+  logging: {
+    // Only error fields are logged, so successful requests add no log volume.
+    fieldLogLevel: 'error',
+    // Keep query bodies and headers out of CloudWatch: the app handles meal and
+    // health records, so user input must never land in the logs.
+    excludeVerboseContent: true,
+    retention: '1 week',
+  },
 })
 
 export function applyEscapeHatches(backend: Backend) {


### PR DESCRIPTION
feat: enable AppSync error logging
AppSync had no logConfig on prod or dev, so failed queries left no
server-side record. When the daily goal intermittently rendered as
zeros, the cause had to be inferred from the code alone.

Log only error-category fields so successful requests add no volume,
and keep excludeVerboseContent on so query bodies and headers stay out
of CloudWatch — the app stores meal and health records.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>